### PR TITLE
Adding st2_api_url as a hiera databound variable 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@
 class st2(
   $version            = '0.8.2',
   $revision           = undef,
+  $st2_api_url        = undef,
   $mistral_git_branch = 'st2-0.8.1',
   $web                = false,
 ) { }

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -7,8 +7,8 @@
 #
 # === Parameters
 #
-#  [*github_oauth_token*] - Version of StackStorm to install
-#  [*st2_api_server*]     - Revision of StackStorm to install
+#  [*st2_api_url*]  - URL of st2_api service -- ex: http://127.0.0.1:9101
+#  [*version*]      - Version of StackStorm WebUI to install
 #
 # === Variables
 #
@@ -19,7 +19,7 @@
 #  include ::nginx
 #
 class st2::profile::web(
-  $st2_api_server = $::ipaddress,
+  $st2_api_url    = $::st2::st2_api_url,
   $version        = $::st2::version,
 ) inherits st2 {
   file { [

--- a/templates/opt/st2web/config.js.erb
+++ b/templates/opt/st2web/config.js.erb
@@ -4,6 +4,6 @@ angular.module('main')
 
     hosts: [{
       name: 'StackStorm',
-      url: '//<%= @st2_api_server %>:9101'
+      <% if @st2_api_url %>url: '<%= @st2_api_url %>',<% end %>
     }]
   });


### PR DESCRIPTION
__Resolution__
This commit allows Angular to specify the remote st2_api URL if necessary.  The previous behavior guessed the endpoint using the host's ip address which does not apply for most cases.

__QA__
- Validated that st2workroom correctly interpolate the st2_api_url into /opt/stackstorm/static/webui/config.js when specified in Hiera.
```
st2workroom/hieradata/common.yaml
st2::st2_api_url: "http://localhost:9101"
```
- Validated that st2workroom correctly does not interpolate the st2_api_url when specified in Hiera.
```
st2workroom/hieradata/common.yaml
#st2::st2_api_url: "http://localhost:9101"
```
- Validated that Angular webapp works without the 'url' config being set and just uses the request url host.
```
vagrant@st2express:/opt/stackstorm/static/webui$ cat config.js
'use strict';
angular.module('main')
  .constant('st2Config', {

    hosts: [{
      name: 'StackStorm',

    }]
  });
```
- Validated that Angular webapp works with the 'url' config being set using st2workroom Vagrant environment (ssh command: vagrant ssh st2express -- -L 9101:localhost:9101, st2_api_url: http://localhost:9101)
```
vagrant@st2express:/opt/stackstorm/static/webui$ cat config.js
'use strict';
angular.module('main')
  .constant('st2Config', {

    hosts: [{
      name: 'StackStorm',
      url: 'http://localhost:9101',
    }]
  });
```