### PR TITLE
Convert to APT/RPM repositories

### DIFF
--- a/lib/puppet/parser/functions/st2_current_revision.rb
+++ b/lib/puppet/parser/functions/st2_current_revision.rb
@@ -13,7 +13,7 @@ module Puppet::Parser::Functions
     }
 
     if auto_update
-      revision = open("https://ops.stackstorm.net/releases/st2/#{version}/#{type}/current/VERSION.txt").read.chomp
+      revision = open("https://downloads.stackstorm.net/releases/st2/#{version}/#{type}/current/VERSION.txt").read.chomp
     else
       revision = sticki_versions[version]
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.8.2',
+  $version            = '0.8.3',
   $revision           = undef,
   $st2_api_url        = undef,
   $mistral_git_branch = 'st2-0.8.1',

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -1,0 +1,31 @@
+# == Class: st2::package::debion
+#
+#  Helper class to install APT repository
+#
+# === Parameters
+#  [*version*] - Version of st2 package to install
+#
+# === Examples
+#  include ::st2::package::debian
+class st2::package::debian {
+  $_version = $::st2::version
+
+  if !defined(Class['::apt']) {
+    include ::apt
+  }
+
+  if $_version =~ /dev$/ {
+    $_suite = "unstable"
+  } else {
+    $_suite = "stable"
+  }
+
+  apt::source { 'stackstorm':
+    location    => 'https://downloads.stackstorm.net/deb/',
+    release     => "${::lsbdistcodename}_${_suite}",
+    repos       => 'main',
+    include_src => false,
+    key         => '6B8C7982',
+    key_source  => 'https://downloads.stackstorm.net/deb/pubkey.gpg',
+  }
+}

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -20,39 +20,31 @@ define st2::package::install(
 
   case $::osfamily {
     'Debian': {
-      $_type     = 'debs'
-      $_provider = 'dpkg'
+      include ::st2::package::debian
+
+      $_type = 'debs'
+
       if $revision {
         $_revision = $revision
       } else {
         $_revision = st2_current_revision($version, $_type)
       }
-      $_suffix   = "_${version}-${_revision}_amd64.deb"
     }
     'RedHat': {
-      $_type     = 'rpms'
-      $_provider = 'rpm'
+      include ::st2::package::redhat
+
+      $_type = 'rpms'
+
       if $revision {
         $_revision = $revision
       } else {
         $_revision = st2_current_revision($version, $_type)
       }
-      $_suffix   = "-${version}-${_revision}.noarch.rpm"
     }
     default: { fail("Class[st2::package]: $st2::notice::unsupported_os") }
   }
 
-  wget::fetch { "Download ${name}":
-    source             => "https://ops.stackstorm.net/releases/st2/${version}/${_type}/${_revision}/${name}${_suffix}",
-    cache_dir          => '/var/cache/wget',
-    destination        => "/tmp/${name}${_suffix}",
-    nocheckcertificate => true,
-    before             => Package[$name],
-  }
-
   package { $name:
-    ensure   => present,
-    source   => "/tmp/${name}${_suffix}",
-    provider => $_provider,
+    ensure => "${version}-${_revision}",
   }
 }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -1,0 +1,29 @@
+# == Class: st2::package::redhat
+#
+#  Helper class to install RPM repository
+#
+# === Parameters
+#  [*version*] - Version of st2 package to install
+#
+# === Examples
+#  include ::st2::package::redhat
+class st2::package::redhat (
+  $version = $::st2::version,
+) inherits st2 {
+  $_os = downcase($::operatingsystem)
+  $_osver = $::operatingsystemrelease
+
+  if $version =~ /dev$/ {
+    $_suite = "unstable"
+  } else {
+    $_suite = "stable"
+  }
+
+  yumrepo { 'stackstorm':
+    ensure   => present,
+    baseurl  => "https://downloads.stackstorm.net/rpm/${_os}/${_osver}/${_suite}",
+    descr    => 'StackStorm RPM Repository',
+    enabled  => 1,
+    gpgcheck => 0,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class st2::params(
     'st2debug',
   ]
   $st2_client_packages = [
-    'st2client',
+    'python-st2client',
   ]
 
   ### Debian Specific Information ###

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -5,7 +5,6 @@
 # === Parameters
 #
 #  [*version*] - Version of StackStorm to install
-#  [*revision*] - Revision of StackStorm to install
 #
 # === Variables
 #
@@ -18,7 +17,6 @@
 #
 class st2::profile::client (
   $version  = $::st2::version,
-  $revision = $::st2::revision,
 ) inherits ::st2 {
 
   include '::st2::notices'
@@ -30,8 +28,8 @@ class st2::profile::client (
   st2::dependencies::install { $_client_dependencies: }
 
   st2::package::install { $_client_packages:
-    version     => $version,
-    revision    => $revision,
+    version  => $version,
+    revision => '1',
   }
 
   ### This should be a versioned download too... currently on master

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -33,6 +33,10 @@ class st2::profile::server (
     'Debian' => '/usr/lib/python2.7/dist-packages',
     'RedHat' => '/usr/lib/python2.7/site-packages',
   }
+  $_register_command = $version ? {
+    /^0.8/  => "${_python_pack}/st2common/bin/registercontent.py",
+    default => "${_python_pack}/st2common/bin/st2-register-content",
+  }
 
   file { $_conf_dir:
     ensure => directory,
@@ -60,7 +64,7 @@ class st2::profile::server (
   }
 
   exec { 'register st2 content':
-    command     => "python ${_python_pack}/st2common/bin/registercontent.py --register-sensors --register-actions --config-file ${_conf_dir}/st2.conf",
+    command     => "python ${_register_command} --register-all --config-file ${_conf_dir}/st2.conf",
     path        => '/usr/bin:/usr/sbin:/bin:/sbin',
     refreshonly => true,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the module to use APT and RPM repositories to retrieve packages over `wget` fetching. Moving between versions (major or revisions) now only requires a change to the `st2::version` parameter of the main class or in hiera.

Also bumps default version to latest stable, 0.8.3 for new users.