### PR TITLE
Initial uWSGI support for Mistral

### DIFF
--- a/files/etc/init/mistral.uwsgi.conf
+++ b/files/etc/init/mistral.uwsgi.conf
@@ -1,0 +1,7 @@
+description "OpenStack Workflow Service"
+start on runlevel [2345]
+stop on runlevel [016]
+respawn
+script
+    /opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --server engine,executor --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral_api.log &> /dev/null &
+end script

--- a/files/etc/systemd/system/mistral.uwsgi.service
+++ b/files/etc/systemd/system/mistral.uwsgi.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mistral Workflow Service
+
+[Service]
+ExecStart=/opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --server engine,executor --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral_api.log &> /dev/null &
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/files/mistral/wsgi.py
+++ b/files/mistral/wsgi.py
@@ -1,0 +1,11 @@
+from mistral import config
+from mistral.api import app
+from mistral.engine1 import rpc
+from oslo.config import cfg
+from oslo.db import options as db_options
+
+db_options.set_defaults(cfg.CONF)
+config.parse_args()
+transport = rpc.get_transport()
+
+application = app.setup_app(transport=transport)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,4 +22,11 @@ class st2(
   $mistral_git_branch = 'st2-0.8.1',
   $web                = false,
   $auth               = false,
-) { }
+  $rabbit_user        = $::st2::params::rabbit_user,
+  $rabbit_pass        = $::st2::params::rabbit_pass,
+  $rabbit_host        = $::st2::params::rabbit_host,
+  $rabbit_port        = $::st2::params::rabbit_port,
+  $st2_api_url        = $::st2::params::st2_api_url,
+  $mistral_api_url    = $::st2::params::mistral_api_url,
+  $mistral_api_port   = $::st2::params::mistral_api_port,
+) inherits ::st2::params { }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -11,17 +11,17 @@ class st2::package::redhat (
   $version = $::st2::version,
 ) inherits st2 {
   $_os = downcase($::operatingsystem)
-  $_osver = $::operatingsystemrelease
+  $_osver = $::operatingsystemmajrelease
 
   if $version =~ /dev$/ {
-    $_suite = "unstable"
+    $_suite = 'unstable'
   } else {
-    $_suite = "stable"
+    $_suite = 'stable'
   }
 
   yumrepo { 'stackstorm':
     ensure   => present,
-    baseurl  => "https://downloads.stackstorm.net/rpm/${_os}/${_osver}/${_suite}",
+    baseurl  => "https://downloads.stackstorm.net/rpm/el/${_osver}/${_suite}",
     descr    => 'StackStorm RPM Repository',
     enabled  => 1,
     gpgcheck => 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,9 +43,53 @@ class st2::params(
     'st2auth',
     'st2debug',
   ]
-  $st2_client_packages = [
-    'python-st2client',
-  ]
+  $st2_client_packages = $::osfamily ? {
+    'RedHat' => 'st2client',
+    'Debian' => 'python-st2client',
+  }
+
+  $db_host             = 'localhost'
+  $db_port             = '27017'
+  $db_name             = 'st2'
+  $db_user             = ''
+  $db_pass             = ''
+  $db_mistral_host     = 'localhost'
+  $db_mistral_user     = 'mistral'
+  $db_mistral_password = 'StackStorm'
+  $rabbit_user         = 'guest'
+  $rabbit_pass         = 'guest'
+  $rabbit_host         = 'localhost'
+  $rabbit_port         = 5672
+  $st2_api_url         = '0.0.0.0'
+  $mistral_api_url     = $st2_api_url
+  $mistral_api_port    = 8989
+  $mistral_v2_base_url = "http://${mistral_api_url}:${mistral_api_port}/v2/"
+  $workflow_url        = "http://${mistral_api_url}:${mistral_api_port}"
+  $rabbit_connection_string = "amqp://${rabbit_user}:${rabbit_port}@${rabbit_host}:${rabbit_port}/"
+
+  $rules_engine      = false
+  $sensor_container  = false
+  $st2api            = false
+  $history           = false
+  $resultstracker    = false
+  $mistral           = false
+  $mistral_executors = 10
+  $actionrunners     = 10
+
+  $github_oauth_token = ''
+  $install_profile   = 'fullinstall'
+
+  $syslog            = false
+  $syslog_host       = 'localhost'
+
+  # One off for RHEL 6. Custom built Python 2.7 should live in /usr/local
+  # so, let's favor that one. Any OS with a custom python should change
+  # this value to '/usr/local' for proper bootstrapping.
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
+    $system_python = '/usr/local'
+  } else {
+    $system_python = undef
+  }
 
   ### Debian Specific Information ###
   $debian_dependencies = [
@@ -83,4 +127,5 @@ class st2::params(
     'python-prettytable',
   ]
   ### END RedHat Specific Information ###
+
 }

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -24,11 +24,18 @@ class st2::profile::client (
 
   $_client_packages = $st2::params::st2_client_packages
   $_client_dependencies = $st2::params::debian_client_dependencies
+  $_revision = st2_current_revision($version, 'rpms')
+  $_system_python = $::st2::params::system_python
 
   st2::dependencies::install { $_client_dependencies: }
 
+  $_version = $::osfamily ? {
+    'RedHat' => "${version}.${_revision}",
+    default  => $version,
+  }
+
   st2::package::install { $_client_packages:
-    version  => $version,
+    version  => $_version,
     revision => '1',
   }
 
@@ -40,6 +47,7 @@ class st2::profile::client (
   }
 
   python::requirements { '/tmp/st2client-requirements.txt':
-    require => Wget::Fetch['Download st2client requirements.txt'],
+    virtualenv => $_system_python,
+    require    => Wget::Fetch['Download st2client requirements.txt'],
   }
 }

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -13,6 +13,9 @@
 #  [*db_max_pool_size*]    - Max DB Pool size for Mistral Connections
 #  [*db_max_overflow*]     - Max DB overload for Mistral Connections
 #  [*db_pool_recycle*]     - DB Pool recycle time
+#  [*uwsgi*]               - Flag to setup uWSGI (default: false)
+#  [*uwsgi_listen_ip*]     - Listen address for uWSGI (default: $::ipaddress)
+#  [*uwsgi_listen_port*]   - Listen port for uWSGI (default: 8989)
 #
 # === Examples
 #
@@ -312,9 +315,20 @@ class st2::profile::mistral(
         'charset' => 'utf-8',
       }
       location_raw_prepend => [
-        'uwsgi_pass  mistral;',
-        'include     /etc/nginx/mistral_params;',
-        'uwsgi_param UWSGI_PYHOME /opt/openstack/mistral/.venv;',
+        'uwsgi_pass   mistral;',
+        'uwsgi_param  UWSGI_PYHOME       /opt/openstack/mistral/.venv;',
+        'uwsgi_param  QUERY_STRING       $query_string;',
+        'uwsgi_param  REQUEST_METHOD     $request_method;',
+        'uwsgi_param  CONTENT_TYPE       $content_type;',
+        'uwsgi_param  CONTENT_LENGTH     $content_length;',
+        'uwsgi_param  REQUEST_URI        $request_uri;',
+        'uwsgi_param  PATH_INFO          $document_uri;',
+        'uwsgi_param  DOCUMENT_ROOT      $document_root;',
+        'uwsgi_param  SERVER_PROTOCOL    $server_protocol;',
+        'uwsgi_param  REMOTE_ADDR        $remote_addr;',
+        'uwsgi_param  REMOTE_PORT        $remote_port;',
+        'uwsgi_param  SERVER_PORT        $server_port;',
+        'uwsgi_param  SERVER_NAME        $server_name;',
       ],
     }
   }

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -14,7 +14,7 @@
 #  [*db_max_overflow*]         - Max DB overload for Mistral Connections
 #  [*db_pool_recycle*]         - DB Pool recycle time
 #  [*uwsgi*]                   - Flag to setup uWSGI (default: false)
-#  [*uwsgi_listen_ip*]         - Listen address for uWSGI (default: $::ipaddress)
+#  [*uwsgi_listen_ip*]         - Listen address for uWSGI (default: *)
 #  [*uwsgi_listen_port*]       - Listen port for uWSGI (default: 8989)
 #  [*uwsgi_processes*]         - spawn the specified number of workers/processes (default: 25)
 #  [*uwsgi_listen_queue_size*] - set the socket listen queue size (default: 128)
@@ -30,20 +30,25 @@
 #  }
 #
 class st2::profile::mistral(
-  $manage_mysql        = false,
-  $git_branch          = $::st2::mistral_git_branch,
-  $db_root_password    = 'StackStorm',
-  $db_mistral_password = 'StackStorm',
-  $db_server           = 'localhost',
-  $db_database         = 'mistral',
-  $db_max_pool_size    = '100',
-  $db_max_overflow     = '400',
-  $db_pool_recycle     = '3600',
-  $uwsgi               = false,
-  $uwsgi_listen_ip     = $::ipaddress,
-  $uwsgi_listen_port   = '8989',
+  $manage_mysql            = false,
+  $git_branch              = $::st2::mistral_git_branch,
+  $db_root_password        = 'StackStorm',
+  $db_mistral_password     = 'StackStorm',
+  $db_server               = 'localhost',
+  $db_database             = 'mistral',
+  $db_max_pool_size        = '100',
+  $db_max_overflow         = '400',
+  $db_pool_recycle         = '3600',
+  $uwsgi                   = false,
+  $uwsgi_listen_ip         = undef,
+  $uwsgi_listen_port       = '8989',
+  $uwsgi_processes         = '25',
+  $uwsgi_listen_queue_size = '128',
+  $manage_init             = true,
 ) inherits st2 {
   include '::st2::dependencies'
+
+  $_system_python = $::st2::params::system_python
 
   # This needs a bit more modeling... need to understand
   # what current mistral code ships with st2 - jdf
@@ -86,8 +91,8 @@ class st2::profile::mistral(
   }
 
   vcsrepo { '/etc/mistral/actions/st2mistral':
-    ensure => present,
-    source => 'https://github.com/StackStorm/st2mistral.git',
+    ensure   => present,
+    source   => 'https://github.com/StackStorm/st2mistral.git',
     revision => $git_branch,
     provider => 'git',
     require  => File['/etc/mistral/actions'],
@@ -99,13 +104,20 @@ class st2::profile::mistral(
   ### END Mistral Downloads ###
 
   ### Bootstrap Python ###
-  python::virtualenv { '/opt/openstack/mistral':
+  ::python::virtualenv { '/opt/openstack/mistral':
     ensure       => present,
-    version      => 'system',
     systempkgs   => false,
     venv_dir     => '/opt/openstack/mistral/.venv',
     cwd          => '/opt/openstack/mistral',
     require      => Vcsrepo['/opt/openstack/mistral'],
+    path         => [
+      '/usr/local/bin',
+      '/usr/local/sbin',
+      '/usr/bin',
+      '/usr/sbin',
+      '/bin',
+      '/sbin',
+    ],
     notify       => [
       Exec['setup mistral', 'setup st2mistral plugin'],
       Exec['python_requirementsmistral'],
@@ -113,27 +125,29 @@ class st2::profile::mistral(
     before       => File['/etc/mistral/database_setup.lock'],
   }
 
-  # Not using virtualenv requirements attribute because oslo has bad wheel, and fails
-  python::requirements { 'mistral':
+  # Not using virtualenv requirements attribute because oslo
+  # has bad wheel, and fails
+  ::python::requirements { 'mistral':
     requirements => '/opt/openstack/mistral/requirements.txt',
     virtualenv   => '/opt/openstack/mistral/.venv',
   }
 
-  python::pip { 'mysql-python':
+  ::python::pip { 'mysql-python':
     ensure     => present,
     virtualenv => '/opt/openstack/mistral/.venv',
     require    => Vcsrepo['/opt/openstack/mistral'],
-    before   => [
+    before     => [
       Exec['setup mistral'],
       Exec['setup st2mistral plugin'],
       Exec['setup mistral database'],
     ],
   }
 
-  python::pip { 'python-mistralclient':
-    ensure => present,
-    url    => "git+https://github.com/StackStorm/python-mistralclient.git@${git_branch}",
-    before   => [
+  ::python::pip { 'python-mistralclient':
+    ensure     => present,
+    virtualenv => $_system_python,
+    url        => "git+https://github.com/StackStorm/python-mistralclient.git@${git_branch}",
+    before     => [
       Exec['setup mistral'],
       Exec['setup st2mistral plugin'],
       Exec['setup mistral database'],
@@ -212,6 +226,38 @@ class st2::profile::mistral(
     value   => 'false',
   }
 
+  ### RabbitMQ Settings ###
+  ini_setting { 'mistral_rabbit_host':
+    ensure  => present,
+    path    => '/etc/mistral/mistral.conf',
+    section => 'DEFAULT',
+    setting => 'rabbit_host',
+    value   => $::st2::rabbit_host,
+  }
+
+  ini_setting { 'mistral_rabbit_port':
+    ensure  => present,
+    path    => '/etc/mistral/mistral.conf',
+    section => 'DEFAULT',
+    setting => 'rabbit_port',
+    value   => $::st2::rabbit_port,
+  }
+
+  ini_setting { 'mistral_rabbit_userid':
+    ensure  => present,
+    path    => '/etc/mistral/mistral.conf',
+    section => 'DEFAULT',
+    setting => 'rabbit_userid',
+    value   => $::st2::rabbit_user,
+  }
+
+  ini_setting { 'mistral_rabbit_password':
+    ensure  => present,
+    path    => '/etc/mistral/mistral.conf',
+    section => 'DEFAULT',
+    setting => 'rabbit_password',
+    value   => $::st2::rabbit_pass,
+  }
 
   File<| tag == 'mistral' |> -> Ini_setting <| tag == 'mistral' |> -> Exec['setup mistral database']
   ### End Mistral Config Modeling ###
@@ -223,14 +269,14 @@ class st2::profile::mistral(
     }
   }
 
-  mysql::db { 'mistral':
+  ::mysql::db { 'mistral':
     user     => 'mistral',
     password => $db_mistral_password,
     before   => Exec['setup mistral database'],
   }
 
   file { '/etc/mistral/database_setup.lock':
-    ensure => file,
+    ensure  => file,
     content => 'This file is the lock file that prevents Puppet from attempting to setup the database again. Delete this file if it needs to be re-run',
     notify  => Exec['setup mistral database'],
   }
@@ -254,33 +300,38 @@ class st2::profile::mistral(
   }
 
   ### Mistral Init Scripts ###
-  $_upstart_init_script = $uwsgi ? {
-    true    => 'puppet:///modules/st2/etc/init/mistral.uwsgi.conf',
-    default => 'puppet:///modules/st2/etc/init/mistral.conf',
-  }
-  $_systemd_init_script = $uwsgi ? {
-    true    => 'puppet:///modules/st2/etc/systemd/system/mistral.uwsgi.service',
-    default => 'puppet:///modules/st2/etc/systemd/system/mistral.service',
-  }
-
-  case $::osfamily {
-    'Debian': {
-      # A bit sloppy, but this only covers Ubuntu right now. Fix this
-      file { '/etc/init/mistral.conf':
-        ensure => file,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0444',
-        source => $_upstart_init_script,
-      }
+  if $manage_init {
+    $_upstart_init_script = $uwsgi ? {
+      true    => 'puppet:///modules/st2/etc/init/mistral.uwsgi.conf',
+      default => 'puppet:///modules/st2/etc/init/mistral.conf',
     }
-    'RedHat': {
-      file { '/etc/systemd/system/mistral.service':
-        ensure => file,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0444',
-        source => $_systemd_init_script,
+    $_systemd_init_script = $uwsgi ? {
+      true    => 'puppet:///modules/st2/etc/systemd/system/mistral.uwsgi.service',
+      default => 'puppet:///modules/st2/etc/systemd/system/mistral.service',
+    }
+
+    case $::osfamily {
+      'Debian': {
+        # A bit sloppy, but this only covers Ubuntu right now. Fix this
+        file { '/etc/init/mistral.conf':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0444',
+          source => $_upstart_init_script,
+        }
+      }
+      'RedHat': {
+        file { '/etc/systemd/system/mistral.service':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0444',
+          source => $_systemd_init_script,
+        }
+      }
+      default: {
+        fail('[st2::profile::mistral] Unsupported Operatingsystem')
       }
     }
   }
@@ -288,64 +339,101 @@ class st2::profile::mistral(
 
   ### START uWSGI Specific Items ###
   if $uwsgi {
-    $_sock_user = $::operatingfamily ? {
+    $_sock_user = $::osfamily ? {
       'Debian' => 'www-data',
       'RedHat' => 'nginx',
     }
+    $_socket = '/var/run/mistral_api.sock'
+    $_wsgi_file = '/opt/openstack/mistral/mistral/api/wsgi.py'
 
-    file { '/opt/stackstorm/mistral_api.sock':
+    # WSGI file exists in 0.9 branch, so this is only temporary.
+    # JDF - 20150424
+    if $::st2::mistral_git_branch =~ /0.8/ {
+      file { $_wsgi_file:
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        source  => 'puppet:///modules/st2/mistral/wsgi.py',
+        require => Vcsrepo['/opt/openstack/mistral'],
+      }
+    }
+
+    ### Mistral API Settings
+    ini_setting { 'mistral_api_host':
+      ensure  => present,
+      path    => '/etc/mistral/mistral.conf',
+      section => 'api',
+      setting => 'host',
+      value   => $::st2::mistral_api_url,
+    }
+
+    ini_setting { 'mistral_api_port':
+      ensure  => present,
+      path    => '/etc/mistral/mistral.conf',
+      section => 'api',
+      setting => 'port',
+      value   => $::st2::mistral_api_port,
+    }
+
+    file { $_socket:
       ensure => present,
       owner  => $_sock_user,
       group  => $_sock_user,
     }
 
-    class { 'uwsgi':
-      install_pip        => false,
-      install_python_dev => false,
+    # Install a process supervisor. Using supervisord to assert
+    # a consistent management experience across systems, regardless
+    # if they are init.d, upstart, or systemd
+    include ::supervisord
+    ::python::pip { 'uwsgi':
+      ensure     => present,
+      virtualenv => $_system_python,
     }
 
-    uwsgi::app { 'mistral':
-      unsure              => present,
-      uid                 => $_sock_user,
-      gid                 => $_sock_user,
-      application_options => {
-        'socket'    => '/opt/stackstorm/mistral_api.sock',
-        'home'      => '/opt/openstack/mistral/.venv/',
-        'processes' => $uwsgi_processes,
-        'listen'    => $uwsgi_listen_queue_size,
-      }
+    ::supervisord::program { 'mistral-uwsgi':
+      command  => "uwsgi -s ${_socket} --wsgi-file ${_wsgi_file} --chown-socket ${_sock_user}:${_sock_user} -H /opt/openstack/mistral/.venv/ -p ${uwsgi_processes} -l ${uwsgi_listen_queue_size}",
+      priority => '100',
     }
 
+    # Proxy all requests from nginx to uwsgi
     include ::nginx
-
-    nginx::resource::upstream { 'mistral-uwsgi':
+    ::nginx::resource::upstream { 'mistral-uwsgi':
       ensure  => present,
-      members => [ 'unix://opt/stackstorm/mistral_api.sock' ],
+      members => [ "unix://${_socket}" ],
     }
 
-    nginx::resource::vhost { 'mistral-uwsgi':
-      ensure            => present,
-      listen_ip         => $uwsgi_ip,
-      listen_port       => $uwsgi_port,
-      vhost_cfg_prepend => {
+    ::nginx::resource::vhost { 'mistral':
+      ensure               => present,
+      listen_ip            => $uwsgi_listen_ip,
+      listen_port          => $uwsgi_listen_port,
+      use_default_location => false,
+      vhost_cfg_prepend    => {
         'charset' => 'utf-8',
-      }
-      location_raw_prepend => [
-        'uwsgi_pass   mistral;',
-        'uwsgi_param  UWSGI_PYHOME       /opt/openstack/mistral/.venv;',
-        'uwsgi_param  QUERY_STRING       $query_string;',
-        'uwsgi_param  REQUEST_METHOD     $request_method;',
-        'uwsgi_param  CONTENT_TYPE       $content_type;',
-        'uwsgi_param  CONTENT_LENGTH     $content_length;',
-        'uwsgi_param  REQUEST_URI        $request_uri;',
-        'uwsgi_param  PATH_INFO          $document_uri;',
-        'uwsgi_param  DOCUMENT_ROOT      $document_root;',
-        'uwsgi_param  SERVER_PROTOCOL    $server_protocol;',
-        'uwsgi_param  REMOTE_ADDR        $remote_addr;',
-        'uwsgi_param  REMOTE_PORT        $remote_port;',
-        'uwsgi_param  SERVER_PORT        $server_port;',
-        'uwsgi_param  SERVER_NAME        $server_name;',
-      ],
+      },
+    }
+
+    ::nginx::resource::location { 'mistral-uwsgi':
+      vhost               => 'mistral',
+      location            => '/',
+      location_custom_cfg => {
+        'uwsgi_pass'  => 'mistral-uwsgi',
+        'uwsgi_param' => [
+          'UWSGI_PYHOME    /opt/openstack/mistral/.venv',
+          'QUERY_STRING    $query_string',
+          'REQUEST_METHOD  $request_method',
+          'CONTENT_TYPE    $content_type',
+          'CONTENT_LENGTH  $content_length',
+          'REQUEST_URI     $request_uri',
+          'PATH_INFO       $document_uri',
+          'DOCUMENT_ROOT   $document_root',
+          'SERVER_PROTOCOL $server_protocol',
+          'REMOTE_ADDR     $remote_addr',
+          'REMOTE_PORT     $remote_port',
+          'SERVER_PORT     $server_port',
+          'SERVER_NAME     $server_name',
+        ],
+      },
     }
   }
 }

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -24,5 +24,4 @@ class st2::profile::python {
       virtualenv => true,
     }
   }
-
 }

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -29,6 +29,7 @@ class st2::profile::server (
 
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
+  $_system_python = $::st2::params::system_python
   $_python_pack = $::osfamily ? {
     'Debian' => '/usr/lib/python2.7/dist-packages',
     'RedHat' => '/usr/lib/python2.7/site-packages',
@@ -57,8 +58,9 @@ class st2::profile::server (
   }
 
   python::requirements { '/tmp/st2server-requirements.txt':
-    require => Wget::Fetch['Download st2server requirements.txt'],
-    before  => Exec['register st2 content'],
+    virtualenv => $_system_python,
+    require    => Wget::Fetch['Download st2server requirements.txt'],
+    before     => Exec['register st2 content'],
   }
 
   st2::package::install { $_server_packages:
@@ -69,7 +71,7 @@ class st2::profile::server (
 
   exec { 'register st2 content':
     command     => "python ${_register_command} --register-all --config-file ${_conf_dir}/st2.conf",
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+    path        => '/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin',
     refreshonly => true,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,9 @@
     {"name":"puppetlabs-mongodb","version_requirement":">= 0.8.0"},
     {"name":"puppetlabs-mysql","version_requirement":">= 3.0.0"},
     {"name":"puppetlabs-rabbitmq","version_requirement":">= 4.1.0"},
-    {"name":"puppetlabs-vcsrepo","version_requirement":">= 1.2.0"}
+    {"name":"puppetlabs-vcsrepo","version_requirement":">= 1.2.0"},
+    {"name":"jfryman-nginx","version_requirement":">= 0.2.6"},
+    {"name":"engage-uwsgi","version_requirement":">= 1.2.0"}
   ]
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",
@@ -22,6 +22,7 @@
     {"name":"puppetlabs-rabbitmq","version_requirement":">= 4.1.0"},
     {"name":"puppetlabs-vcsrepo","version_requirement":">= 1.2.0"},
     {"name":"jfryman-nginx","version_requirement":">= 0.2.6"},
+    {"name":"ajcrowe-supervisord","version_requirement":">= 0.5.2"},
     {"name":"engage-uwsgi","version_requirement":">= 1.2.0"}
   ]
 }


### PR DESCRIPTION
This PR adds the initial support for uWSGI to the Puppet module. Modifies the `Class[st2::profile::mistral]` to add new uWSGI parameters:

* `uwsgi`            - Flag to setup uWSGI (default: false)
* `uwsgi_listen_ip`     - Listen address for uWSGI (default: `$::ipaddress`)
* `uwsgi_listen_port` - Listen port for uWSGI (default: 8989)


/cc https://github.com/StackStorm/mistral/pull/4 https://github.com/StackStorm/mistral/pull/5