### PR TITLE
Add retries to pack installation

### DIFF
--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -27,11 +27,13 @@ define st2::pack (
   else { $_repo_url = '' }
 
   exec { "install-st2-pack-${pack}":
-    command => "st2 run packs.install packs=${pack} ${_repo_url}",
-    creates => "/opt/stackstorm/packs/${pack}",
-    path    => '/usr/sbin:/usr/bin:/sbin:/bin',
-    require => Exec['start st2'],
-    notify  => Exec['restart-st2'],
+    command   => "st2 run packs.install packs=${pack} ${_repo_url}",
+    creates   => "/opt/stackstorm/packs/${pack}",
+    path      => '/usr/sbin:/usr/bin:/sbin:/bin',
+    tries     => '5',
+    try_sleep => '10',
+    require   => Exec['start st2'],
+    notify    => Exec['restart-st2'],
   }
 
   ensure_resource('exec', 'restart-st2', {

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -103,13 +103,6 @@ class st2::profile::server (
     unless  => 'ps ax | grep -v grep | grep actionrunner',
     path    => '/usr/bin:/usr/sbin:/bin:/sbin',
     require => Exec['register st2 content'],
-    notify  => Exec['warmup'],
-  }
-
-  exec { 'warmup':
-    command     => 'sleep 20',
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-    refreshonly => true,
   }
 
   St2::Package::Install<| tag == 'st2::profile::server' |>

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
On first boot, st2 takes a moment to initialize, and if you hit
a pack installation command at the wrong time, you are liable
to run into something like this:

```
/Stage[main]/St2::Packs/St2::Pack[hubot]/Exec[install-st2-pack-hubot]/returns:
  ERROR: HTTPConnectionPool(host='localhost', port=9101): Max retries exceeded
  with url: /v1/actions/packs.install (Caused by <class 'socket.error'>:
  [Errno 111] Connection refused)
```

This commit purposely introduces retries into pack installation with
a 10 second back-off time period in order to allow successful convergence
on the first pass.