### PR TITLE
Update Debian `st2client` package number

### DIFF
--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -29,6 +29,13 @@ define st2::package::install(
       } else {
         $_revision = st2_current_revision($version, $_type)
       }
+
+      # Temporary Hack while fixing build pipeline
+      if $name =~ /client/ {
+        $_version = "${version}.${_revision}-1"
+      } else {
+        $_version = "${version}-${_revision}"
+      }
     }
     'RedHat': {
       include ::st2::package::redhat
@@ -40,11 +47,13 @@ define st2::package::install(
       } else {
         $_revision = st2_current_revision($version, $_type)
       }
+
+      $_version = "${version}-${_revision}"
     }
     default: { fail("Class[st2::package]: $st2::notice::unsupported_os") }
   }
 
   package { $name:
-    ensure => "${version}-${_revision}",
+    ensure => $_version,
   }
 }

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -17,6 +17,7 @@
 #
 class st2::profile::client (
   $version  = $::st2::version,
+  $revision = $::st2::revision,
 ) inherits ::st2 {
 
   include '::st2::notices'
@@ -29,7 +30,6 @@ class st2::profile::client (
 
   st2::package::install { $_client_packages:
     version  => $version,
-    revision => '1',
   }
 
   ### This should be a versioned download too... currently on master

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
While working out some flow in our automated build, the version number for `st2client` needs to be temporarily modified to allow downloads of 0.9.0.

