### PR TITLE
ST2 Authentication

### DIFF
--- a/manifests/auth/mongodb.pp
+++ b/manifests/auth/mongodb.pp
@@ -1,0 +1,117 @@
+# Class: st2::auth::mongodb
+#
+#  Auth class to configure and setup MongoDB Based Authentication
+#
+# Parameters:
+#
+# [*debug*] - Enable Debug (default: false)
+# [*db_host*] - MongoDB Host to connect to (default: 127.0.0.1)
+# [*db_port*] - MongoDB Port to connect to (default: 27017)
+# [*db_name*] - MongoDB DB storing credentials (default: st2auth)
+# [*ssl*] - Enable SSL (default: false)
+# [*ssl_cert*] - Path to SSL Certificate file
+# [*ssl_key*] - Path to SSL Key file
+# [*logging_file*] - Path to logging configuration file
+#
+# Usage:
+#
+#  include ::st2::auth::mongodb
+#
+#  class { 'st2::auth::mongodb':
+#    db_host  => 'mongodb.stackstorm.net',
+#    ssl      => true,
+#    ssl_cert => '/etc/ssl/cert.crt',
+#    ssl_key  => '/etc/ssl/cert.key',
+#  }
+class st2::auth::mongodb (
+  $debug         = false,
+  $db_host       = '127.0.0.1',
+  $db_port       = '27017',
+  $db_name       = 'st2auth',
+  $ssl           = false,
+  $ssl_cert      = undef,
+  $ssl_key       = undef,
+  $logging_file  = '/etc/st2api/logging.conf',
+) {
+  $_debug = $debug ? {
+    true    => 'True',
+    default => 'False',
+  }
+  $_ssl = $ssl ? {
+    true    => 'True',
+    default => 'False',
+  }
+  $_api_url = $::st2::api_url
+
+  ini_setting { 'auth_mode':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'mode',
+    value   => 'standalone',
+  }
+  ini_setting { 'auth_backend':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'backend',
+    value   => 'mongodb',
+  }
+  ini_setting { 'auth_backend_kwargs':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'backend_kwargs',
+    value   => "{\"db_host\": \"${db_host}\", \"db_port\": \"${db_port}\", \"db_name\": \"${db_name}\"}",
+  }
+  ini_setting { 'auth_debug':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'debug',
+    value   => $_debug,
+  }
+  ini_setting { 'auth_ssl':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'use_ssl',
+    value   => $_ssl,
+  }
+  ini_setting { 'auth_api_url':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'api_url',
+    value   => $_api_url,
+  }
+  ini_setting { 'auth_logging_file':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'logging',
+    value   => $logging_file,
+  }
+
+  # SSL Settings
+  if $ssl {
+    if !$ssl_cert or !$ssl_key {
+      fail('[st2::auth::standalone] Missing $ssl_cert or $ssl_key to enable SSL')
+    }
+
+    ini_setting { 'auth_ssl_cert':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'auth',
+      setting => 'cert',
+      value   => $ssl_cert,
+    }
+    ini_setting { 'auth_ssl_key':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'auth',
+      setting => 'key',
+      value   => $ssl_key,
+    }
+  }
+}

--- a/manifests/auth/proxy.pp
+++ b/manifests/auth/proxy.pp
@@ -1,0 +1,52 @@
+# Class: st2::auth::proxy
+#
+#  Auth class to configure and setup proxy authentication
+#
+# Parameters:
+#
+# [*debug*] - Enable Debug (default: false)
+# [*logging_file*] - Path to logging configuration file
+#
+# Usage:
+#
+#  include ::st2::auth::proxy
+#
+class st2::auth::proxy (
+  $debug         = false,
+  $logging_file  = '/etc/st2api/logging.conf',
+) {
+  $_debug = $debug ? {
+    true    => 'True',
+    default => 'False',
+  }
+  $_api_url = $::st2::api_url
+
+  ini_setting { 'auth_mode':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'mode',
+    value   => 'proxy',
+  }
+  ini_setting { 'auth_debug':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'debug',
+    value   => $_debug,
+  }
+  ini_setting { 'auth_api_url':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'api_url',
+    value   => $_api_url,
+  }
+  ini_setting { 'auth_logging_file':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'logging',
+    value   => $logging_file,
+  }
+}

--- a/manifests/auth/standalone.pp
+++ b/manifests/auth/standalone.pp
@@ -1,0 +1,137 @@
+# Class: st2::auth::standalone
+#
+#  Auth class to configure and setup Standalone Authentication
+#
+# Parameters:
+#
+# [*debug*] - Enable Debug (default: false)
+# [*ssl*] - Enable SSL (default: false)
+# [*ssl_cert*] - Path to SSL Certificate file
+# [*ssl_key*] - Path to SSL Key file
+# [*test_user*] - Flag to enable the test user (default: true)
+# [*logging_file*] - Path to logging configuration file
+# [*htpasswd_file*] - Path to htpasswd file
+#
+# Usage:
+#
+#  include ::st2::auth::standalone
+#
+#  class { 'st2::auth::standalone':
+#    ssl      => true,
+#    ssl_cert => '/etc/ssl/cert.crt',
+#    ssl_key  => '/etc/ssl/cert.key',
+#  }
+class st2::auth::standalone(
+  $debug         = false,
+  $ssl           = false,
+  $ssl_cert      = undef,
+  $ssl_key       = undef,
+  $test_user     = true,
+  $logging_file  = '/etc/st2api/logging.conf',
+  $htpasswd_file = '/etc/st2/htpasswd',
+) {
+  $_debug = $debug ? {
+    true    => 'True',
+    default => 'False',
+  }
+  $_ssl = $ssl ? {
+    true    => 'True',
+    default => 'False',
+  }
+  $_api_url = $::st2::api_url
+  $_auth_users = hiera_hash('st2::auth_users', {})
+  $_cli_username = $::st2::cli_username
+  $_cli_password = $::st2::cli_password
+
+  ini_setting { 'auth_mode':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'mode',
+    value   => 'standalone',
+  }
+  ini_setting { 'auth_backend':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'backend',
+    value   => 'flat_file',
+  }
+  ini_setting { 'auth_backend_kwargs':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'backend_kwargs',
+    value   => "{\"file_path\": \"${htpasswd_file}\"}",
+  }
+  ini_setting { 'auth_debug':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'debug',
+    value   => $_debug,
+  }
+  ini_setting { 'auth_ssl':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'use_ssl',
+    value   => $_ssl,
+  }
+  ini_setting { 'auth_api_url':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'api_url',
+    value   => $_api_url,
+  }
+  ini_setting { 'auth_logging_file':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'logging',
+    value   => $logging_file,
+  }
+
+  # System Users
+  $_testuser_ensure = $test_user ? {
+    true    => present,
+    default => absent,
+  }
+  st2::auth_user { 'testu':
+    ensure    => $_testuser_ensure,
+    password => 'testp',
+  }
+  st2::auth_user { $_cli_username:
+    password => $_cli_password,
+  }
+
+  if $test_user {
+    notify { $::st2::notices::auth_test_user_enabled: }
+  }
+
+  # Automatically generate users from Hiera
+  create_resources('st2::auth_user', $_auth_users)
+
+  # SSL Settings
+  if $ssl {
+    if !$ssl_cert or !$ssl_key {
+      fail('[st2::auth::standalone] Missing $ssl_cert or $ssl_key to enable SSL')
+    }
+
+    ini_setting { 'auth_ssl_cert':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'auth',
+      setting => 'cert',
+      value   => $ssl_cert,
+    }
+    ini_setting { 'auth_ssl_key':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'auth',
+      setting => 'key',
+      value   => $ssl_key,
+    }
+  }
+}

--- a/manifests/auth_user.pp
+++ b/manifests/auth_user.pp
@@ -1,0 +1,23 @@
+# Definition: st2::auth_user
+#
+#  Friendly helper to manage standalone auth for StackStorm
+#
+# Usage
+#
+#  st2::auth_user { 'jfryman':
+#    password => 'neato!',
+#  }
+define st2::auth_user(
+  $ensure   = present,
+  $password = undef,
+) {
+  include ::st2::auth::standalone
+  $_htpasswd_file = $::st2::auth::standalone::htpasswd_file
+
+  httpauth { $name:
+    ensure    => $ensure,
+    password  => $password,
+    mechanism => 'basic',
+    file      => $_htpasswd_file,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,10 @@ class st2(
   $version            = '0.9.0',
   $revision           = undef,
   $mistral_git_branch = 'st2-0.9.0',
-  $api_url            = undef,
-  $auth               = false,
-  $auth_url           = undef,
+  $api_url            = "http://${::fqdn}:9101",
+  $auth               = true,
+  $auth_url           = "http://${::fqdn}:9100",
+  $auth_mode          = 'standalone',
+  $cli_username       = 'puppet',
+  $cli_password       = fqdn_rand_string(32),
 ) { }

--- a/manifests/notices.pp
+++ b/manifests/notices.pp
@@ -17,6 +17,7 @@ class st2::notices {
   $user_missing_client_keys = "ssh_public_key and ssh_key_type need to be supplied for this resource. Help can be found in INSTALL.md if needed"
   $user_missing_private_key = "ssh_private_key needs to be supplied for this resource. Help can be found in INSTALL.md if needed"
   $unsupported_os = "Your platform is not yet supported. Please file a bug or submit a bug to $st2::params::repo_url"
+  $auth_test_user_enabled = "The test user for the WebUI is **ENABLED**. Ensure to disable before deploying to production"
   $web_no_oauth_token = "The Web Interface is currently in limited beta. You will need a key to test this out. Please email us at support@stackstorm.com if you are interested in trying it out and providing feedback"
 
 }

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -22,18 +22,22 @@ define st2::pack (
   $repo_url = undef,
   $config   = undef,
 ) {
+  include ::st2
+  $_cli_username = $::st2::cli_username
+  $_cli_password = $::st2::cli_password
+  $_auth = $::st2::auth
 
   if $repo_url { $_repo_url = "repo_url=${repo_url}" }
   else { $_repo_url = '' }
 
   exec { "install-st2-pack-${pack}":
-    command   => "st2 run packs.install packs=${pack} ${_repo_url}",
-    creates   => "/opt/stackstorm/packs/${pack}",
-    path      => '/usr/sbin:/usr/bin:/sbin:/bin',
-    tries     => '5',
-    try_sleep => '10',
-    require   => Exec['start st2'],
-    notify    => Exec['restart-st2'],
+    command     => "st2 run packs.install packs=${pack} ${_repo_url}",
+    creates     => "/opt/stackstorm/packs/${pack}",
+    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
+    tries       => '5',
+    try_sleep   => '10',
+    require     => Exec['start st2'],
+    notify      => Exec['restart-st2'],
   }
 
   ensure_resource('exec', 'restart-st2', {

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -26,6 +26,12 @@ class st2::profile::client (
   $_client_packages = $st2::params::st2_client_packages
   $_client_dependencies = $st2::params::debian_client_dependencies
 
+  $_auth = $::st2::auth
+  $_api_url = $::st2::api_url
+  $_auth_url = $::st2::auth_url
+  $_cli_username = $::st2::cli_username
+  $_cli_password = $::st2::cli_password
+
   st2::dependencies::install { $_client_dependencies: }
 
   st2::package::install { $_client_packages:
@@ -42,4 +48,50 @@ class st2::profile::client (
   python::requirements { '/tmp/st2client-requirements.txt':
     require => Wget::Fetch['Download st2client requirements.txt'],
   }
+
+  file { '/root/.st2':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0700',
+  }
+
+  if $_api_url {
+    ini_setting { 'api_url':
+      ensure  => 'present',
+      path    => '/root/.st2/config',
+      section => 'api',
+      setting => 'url',
+      value   => "${_api_url}/v1,
+    }
+  }
+
+  if $_auth_url {
+    ini_setting { 'auth_url':
+      ensure  => 'present',
+      path    => '/root/.st2/config',
+      section => 'auth',
+      setting => 'url',
+      value   => $_auth_url,
+    }
+  }
+
+  if $auth {
+    ini_setting { 'credentials_username':
+      ensure  => 'present',
+      path    => '/root/.st2/config',
+      section => 'credentials',
+      setting => 'username',
+      value   => $_cli_username,
+    }
+    ini_setting { 'credentials_password':
+      ensure  => 'present',
+      path    => '/root/.st2/config',
+      section => 'credentials',
+      setting => 'password',
+      value   => $_cli_password,
+    }
+  }
+
+  File['/root/.st2'] -> Ini_setting <| tag == 'st2::profile::client' |>
 }

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -62,7 +62,7 @@ class st2::profile::client (
       path    => '/root/.st2/config',
       section => 'api',
       setting => 'url',
-      value   => "${_api_url}/v1,
+      value   => "${_api_url}/v1",
     }
   }
 

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -36,6 +36,7 @@ class st2::profile::fullinstall inherits st2 {
   Anchor['st2::pre_reqs']
   -> class { '::st2::profile::client': }
   -> class { '::st2::profile::server': }
+  -> class { '::st2::auth::standalone': }
   -> class { '::st2::profile::web': }
   -> class { '::st2::stanley': }
 

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -29,6 +29,7 @@ class st2::profile::server (
 
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
+
   $_python_pack = $::osfamily ? {
     'Debian' => '/usr/lib/python2.7/dist-packages',
     'RedHat' => '/usr/lib/python2.7/site-packages',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",
@@ -8,7 +8,8 @@
   "project_page": "https://github.com/StackStorm/puppet-st2",
   "issues_url": "https://github.com/StackStorm/puppet-st2/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"jamtur01/httpauth","version_requirement":">= 0.0.3"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0"},
     {"name":"nanliu-staging","version_requirement":">= 1.0.2"},
     {"name":"puppetlabs-apt","version_requirement":">= 1.7.0"},
     {"name":"maestrodev-git","version_requirement":">= 1.0.6"},


### PR DESCRIPTION
This PR adds authentication setup to the puppet module. Changes in this module include:

* Default `standalone` backend. In `st2::profile::fullinstall`, `standalone` file backend is setup.
* Modules for `file_based`, `mongodb`, and `proxy` authentication methods.

Once authentication is enabled, then the CLI stops working until https://github.com/StackStorm/st2/pull/1444 has been merged into `0.9.x` and made available.