### PR TITLE
Bump default version to 0.11.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.11.0',
+  $version            = '0.11.1',
   $revision           = undef,
   $mistral_git_branch = 'st2-0.9.0',
   $api_url            = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the default version of the Puppet module to 0.11.1