### PR TITLE
Updates and improvements

### DIFF
--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -21,6 +21,7 @@ define st2::pack (
   $pack     = $name,
   $repo_url = undef,
   $register = undef,
+  $subtree  = undef,
   $config   = undef,
 ) {
   include ::st2
@@ -30,10 +31,12 @@ define st2::pack (
 
   if $repo_url { $_repo_url = "repo_url=${repo_url}" }
   if $register { $_register = "register=${register}" }
+  if $subtree { $_subtree = "subtree=${subtree}" }
+
   else { $_repo_url = '' }
 
   exec { "install-st2-pack-${pack}":
-    command     => "st2 run packs.install packs=${pack} ${_repo_url} ${_register}",
+    command     => "st2 run packs.install packs=${pack} ${_repo_url} ${_register} ${_subtree}",
     creates     => "/opt/stackstorm/packs/${pack}",
     path        => '/usr/sbin:/usr/bin:/sbin:/bin',
     tries       => '5',

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -20,6 +20,7 @@ define st2::pack (
   $ensure   = present,
   $pack     = $name,
   $repo_url = undef,
+  $register = undef,
   $config   = undef,
 ) {
   include ::st2
@@ -28,10 +29,11 @@ define st2::pack (
   $_auth = $::st2::auth
 
   if $repo_url { $_repo_url = "repo_url=${repo_url}" }
+  if $register { $_register = "register=${register}" }
   else { $_repo_url = '' }
 
   exec { "install-st2-pack-${pack}":
-    command     => "st2 run packs.install packs=${pack} ${_repo_url}",
+    command     => "st2 run packs.install packs=${pack} ${_repo_url} ${_register}",
     creates     => "/opt/stackstorm/packs/${pack}",
     path        => '/usr/sbin:/usr/bin:/sbin:/bin',
     tries       => '5',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR addresses #21 and #22, and adds several new parameters to the `st2::pack` pack deployment resource. Namely:

* `subtree` - allow control of pack deploys stored within the packs directory of a repo or at TLD.
* `register` - all the ability to register selective parts of a pack, or all.

/cc https://github.com/StackStorm/st2/issues/1616