### PR TITLE
Don't disable SSL certificate verification

### DIFF
--- a/lib/puppet/parser/functions/st2_current_revision.rb
+++ b/lib/puppet/parser/functions/st2_current_revision.rb
@@ -1,5 +1,4 @@
 require 'open-uri'
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
 module Puppet::Parser::Functions
   newfunction(:st2_current_revision, :type => :rvalue) do |args|


### PR DESCRIPTION
Having `OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE` here is going to disable all certificate verification inside puppet, which is suboptimal. `download.stackstorm.net` seems to have a valid certificate anyway, so this probably isn't fixing anything.