### PR TITLE
enable auto-updates of stable version

### DIFF
--- a/lib/puppet/parser/functions/st2_current_revision.rb
+++ b/lib/puppet/parser/functions/st2_current_revision.rb
@@ -1,5 +1,4 @@
 require 'open-uri'
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
 module Puppet::Parser::Functions
   newfunction(:st2_current_revision, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/st2_latest_stable.rb
+++ b/lib/puppet/parser/functions/st2_latest_stable.rb
@@ -1,0 +1,8 @@
+require 'open-uri'
+
+module Puppet::Parser::Functions
+  newfunction(:st2_latest_stable, :type => :rvalue) do |args|
+     page = open("https://downloads.stackstorm.net/deb/pool/trusty_stable/main/s/st2api/").read
+     page.split.select { |x| x =~ /href=\"st2api/ }.collect { |x| x.scan(/>(.*)</) }.flatten.collect { |x| x.scan(/_(.*)-/).first[0] }.sort_by { |x| [x.split('.')[2].to_i,x.split('.')[1].to_i] }.last
+  end
+end

--- a/lib/puppet/parser/functions/st2_latest_unstable.rb
+++ b/lib/puppet/parser/functions/st2_latest_unstable.rb
@@ -1,0 +1,8 @@
+require 'open-uri'
+
+module Puppet::Parser::Functions
+  newfunction(:st2_latest_stable, :type => :rvalue) do |args|
+     page = open("https://downloads.stackstorm.net/deb/pool/trusty_stable/main/s/st2api/").read
+     page.split.select { |x| x =~ /href=\"st2api/ }.collect { |x| x.scan(/>(.*)</) }.flatten.collect { |x| x.scan(/_(.*)-/).first[0] }.sort_by { |x| [x.split('.')[2].to_i,x.split('.')[1].to_i] }.last
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.11.1',
+  $version            = st2_latest_stable(),
   $revision           = undef,
   $mistral_git_branch = 'st2-0.9.0',
   $api_url            = undef,


### PR DESCRIPTION
This PR adds the ability for the Puppet Module to stay up-to-date with latest stable by default. User can lock to a specific version with Hiera, otherwise tracks upstream latest.

Please ignore my horrible string manipulation. If `nokogiri` were available, this would be much cleaner. Alas.