### PR TITLE
Upstart init scripts

### DIFF
--- a/files/etc/init/st2actionrunner.conf
+++ b/files/etc/init/st2actionrunner.conf
@@ -1,0 +1,29 @@
+# StackStorm actionrunner main task. Starts up multiple workers.
+#
+
+description     "StackStorm actionrunner task"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+
+script
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  NAME=st2rulesengine
+  WORKERSNUM=${WORKERSNUM:-10}
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  for i in $(seq 1 $WORKERSNUM)
+  do
+    start st2actionrunner ${DEFAULT_ARGS}
+  done
+end script

--- a/files/etc/init/st2api.conf
+++ b/files/etc/init/st2api.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2api service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2api
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/files/etc/init/st2auth.conf
+++ b/files/etc/init/st2auth.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2auth service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2auth
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/files/etc/init/st2notifier.conf
+++ b/files/etc/init/st2notifier.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2notifier service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2notifier
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/files/etc/init/st2resultstracker.conf
+++ b/files/etc/init/st2resultstracker.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2resultstracker service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2resultstracker
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/files/etc/init/st2rulesengine.conf
+++ b/files/etc/init/st2rulesengine.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2rulesengine service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2rulesengine
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/files/etc/init/st2sensorcontainer.conf
+++ b/files/etc/init/st2sensorcontainer.conf
@@ -1,0 +1,21 @@
+description     "StackStorm st2sensorcontainer service"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on filesystem and net-device-up IFACE!=lo
+stop on starting rc RUNLEVEL=[016]
+
+respawn
+respawn limit 2 5
+
+umask 007
+kill timeout 60
+
+script
+  NAME=st2sensorcontainer
+  DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
+
+  # Read configuration variable file if it is present
+  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+  /usr/bin/$NAME ${DEFAULT_ARGS}
+end script

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@
 #  [*cli_password*]       - CLI config - Auth Password
 #  [*cli_api_url*]        - CLI config - API URL
 #  [*cli_auth_url*]       - CLI config - Auth URL
+#  [*ng_init*]            - [Experimental] Init scripts for services. Upstart ONLY
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
 #
@@ -42,4 +43,5 @@ class st2(
   $cli_password       = fqdn_rand_string(32),
   $cli_api_url        = 'http://localhost:9101',
   $cli_auth_url       = 'http://localhost:9100',
+  $ng_init            = false,
 ) { }

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -28,6 +28,7 @@ define st2::pack (
   $_cli_username = $::st2::cli_username
   $_cli_password = $::st2::cli_password
   $_auth = $::st2::auth
+  $_ng_init = $::st2::ng_init
 
   $_repo_url = $repo_url ? {
     undef   => '',
@@ -48,8 +49,12 @@ define st2::pack (
     path        => '/usr/sbin:/usr/bin:/sbin:/bin',
     tries       => '5',
     try_sleep   => '10',
-    require     => Exec['start st2'],
-    notify      => Exec['restart-st2'],
+  }
+
+  if $_ng_init {
+    Service<| tag == 'st2::profile::service' |> -> Exec["install-st2-pack-${name}"] -> Exec['restart-st2']
+  } else {
+    Exec['start st2'] -> Exec["install-st2-pack-${pack}"] -> Exec['restart-st2']
   }
 
   ensure_resource('exec', 'restart-st2', {


### PR DESCRIPTION
This PR introduces init scripts for StackStorm services. This is a temporary fix, as work is underway to properly package and distribute init scripts with our core packages. This PR grabs and modifies the init scripts as an intermediate step and gets them installed. Only supports Ubuntu/Upstart for right now.

/cc @dennybaa https://github.com/StackStorm/st2/pull/1718