### PR TITLE
Upstart init script Fixes

### DIFF
--- a/files/etc/init/st2actionrunner.conf
+++ b/files/etc/init/st2actionrunner.conf
@@ -6,20 +6,3 @@ author          "StackStorm Engineering <opsadmin@stackstorm.com>"
 
 start on filesystem and net-device-up IFACE!=lo
 stop on starting rc RUNLEVEL=[016]
-
-respawn
-respawn limit 2 5
-
-umask 007
-kill timeout 60
-
-script
-  # Read configuration variable file if it is present
-  [ -r /etc/default/$NAME ] && . /etc/default/$NAME
-  WORKERSNUM=${WORKERSNUM:-10}
-
-  for i in $(seq 1 $WORKERSNUM)
-  do
-    start st2actionrunner-worker WORKERID=$i
-  done
-end script

--- a/manifests/helper/actionrunner_upstart.pp
+++ b/manifests/helper/actionrunner_upstart.pp
@@ -9,7 +9,7 @@
 define st2::helper::actionrunner_upstart (
   $worker_id = $name,
 ) {
-  file { "/etc/init/st2actionrunner-worker-${worker_id}.conf":
+  file { "/etc/init/st2actionrunner-${worker_id}.conf":
     ensure  => present,
     owner   => 'root',
     group   => 'root',

--- a/manifests/helper/actionrunner_upstart.pp
+++ b/manifests/helper/actionrunner_upstart.pp
@@ -14,6 +14,6 @@ define st2::helper::actionrunner_upstart (
     owner   => 'root',
     group   => 'root',
     mode    => '0444',
-    content => template('st2/etc/init/actionrunner-worker.conf.erb'),
+    content => template('st2/etc/init/st2actionrunner-worker.conf.erb'),
   }
 }

--- a/manifests/helper/actionrunner_upstart.pp
+++ b/manifests/helper/actionrunner_upstart.pp
@@ -1,0 +1,19 @@
+# Definition: st2::helper::actionrunner_upstart
+#
+#  This defined type is used to simulate a loop in
+#  pre-4.0 clients, creating N instances of the
+#  st2actionrunner-worker upstart script.
+#
+#  Usage:
+#    st2::helper::actionrunner_upstart { '1': }
+define st2::helper::actionrunner_upstart (
+  $worker_id = $name,
+) {
+  file { "/etc/init/st2actionrunner-worker-${worker_id}.conf":
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => template('st2/etc/init/actionrunner-worker.conf.erb'),
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@
 #  [*cli_password*]       - CLI config - Auth Password
 #  [*cli_api_url*]        - CLI config - API URL
 #  [*cli_auth_url*]       - CLI config - Auth URL
+#  [*workers*]            - Set the number of actionrunner processes to start
 #  [*ng_init*]            - [Experimental] Init scripts for services. Upstart ONLY
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
@@ -43,5 +44,6 @@ class st2(
   $cli_password       = fqdn_rand_string(32),
   $cli_api_url        = 'http://localhost:9101',
   $cli_auth_url       = 'http://localhost:9100',
+  $workers            = 8,
   $ng_init            = false,
 ) { }

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -153,7 +153,7 @@ class st2::profile::server (
     }
 
     # Spin up any number of workers as needed
-    $_workers = inline_template('<%= (0..@workers).to_a.collect { |x| x.to_s } %>')
+    $_workers = prefix(range("0", "${workers}"), "worker")
     ::st2::helper::actionrunner_upstart { $_workers: }
 
     service { 'st2actionrunner':

--- a/templates/etc/init/st2actionrunner-worker.conf.erb
+++ b/templates/etc/init/st2actionrunner-worker.conf.erb
@@ -1,15 +1,17 @@
 # StackStorm actionrunner worker task. Spawns st2actionrunner worker.
 #
 
-description     "StackStorm actionrunner worker task"
+description     "StackStorm actionrunner worker task <%= @worker_id %>"
+author          "StackStorm Engineering <opsadmin@stackstorm.com>"
+
+start on starting st2actionrunner
+stop on stopping st2actionrunner
 
 respawn
 respawn limit 2 5
 
 umask 007
 kill timeout 60
-
-instance $WORKERID
 
 script
   NAME=st2actionrunner


### PR DESCRIPTION
This PR fixes a few issues with the init scripts:

* Adds unique upstart scripts for each actionrunner, vs attempting to let upstart manage many workers
* Add `st2web` init script, properly adheres to `ST2_DISABLE_HTTPSERVER` flag, just like `st2ctl`.

This allows `st2ctl` to work 100% with the `ng_init` flag set.