### PR TITLE
Add environment flags for network services

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ Hiera data bindings. A few notable parameters to take note of:
 All other classes are documented with Puppetdoc. Please refer to specific
 classes for use and configuration.
 
+## NG-Init
+
+As of StackStorm v0.12.0, the transition to init scripts has begun. To enable
+init scripts (Upstart only, currently. SystemD in progress), add the following flag
+to hiera or via code composition.
+
+* `st2::ng_init` - Boolean
+
+This will apply init scripts to be managed by the OS.
+
+Each of the network services has an environment variable that can be passed
+that will disable the spawning of the stand-alone service. This is useful
+when setting up uWSGI or other services. This is necessary to remain
+compatability with `st2ctl` during the transition period to init scripts.
+
+* `ST2_DISABLE_HTTP` - Disable SimpleHTTPServer for WebUI
+* `ST2_DISABLE_API` - Disable StandAlone API Server
+* `ST2_DISABLE_AUTH` - Disable StandAlone Auth Server
+
 ### Profiles:
 
 * `st2::profile::client` - Profile to install all client libraries for st2

--- a/files/etc/init/st2api.conf
+++ b/files/etc/init/st2api.conf
@@ -17,5 +17,7 @@ script
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-  /usr/bin/$NAME ${DEFAULT_ARGS}
+  if [ -z "${ST2_DISABLE_API}" ]; then
+    /usr/bin/$NAME ${DEFAULT_ARGS}
+  fi
 end script

--- a/files/etc/init/st2auth.conf
+++ b/files/etc/init/st2auth.conf
@@ -17,5 +17,7 @@ script
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-  /usr/bin/$NAME ${DEFAULT_ARGS}
+  if [ -z "${ST2_DISABLE_AUTH}" ]; then
+    /usr/bin/$NAME ${DEFAULT_ARGS}
+  fi
 end script

--- a/files/etc/init/st2web.conf
+++ b/files/etc/init/st2web.conf
@@ -17,6 +17,8 @@ script
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
   WEBUI_PORT=${WEBUI_PORT:-8080}
 
-  cd /opt/stackstorm/static/webui/
-  nohup python -m SimpleHTTPServer $WEBUI_PORT
+  if [ -z "${ST2_DISABLE_HTTP}" ]; then
+    cd /opt/stackstorm/static/webui/
+    nohup python -m SimpleHTTPServer $WEBUI_PORT
+  fi
 end script


### PR DESCRIPTION
This PR adds environment flags to network services when using new-style init scripts.

This is necessary to allow the Puppet module to still apply init scripts to the system, allowing `st2ctl` to continue to work until refactored to better control each service independently.

In doing this, the init script is still created, allowing us to create an anchor for other services to watch (a la https://github.com/StackStorm/puppet-st2/pull/31/files#diff-90721a90821a0f1b7129de28e6801b41R7)