### PR TITLE
Mistral Service Management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,4 +46,6 @@ class st2(
   $cli_auth_url       = 'http://localhost:9100',
   $workers            = 8,
   $ng_init            = false,
+  $mistral_api_url    = undef,
+  $mistral_api_port   = '8989',
 ) { }

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -13,8 +13,8 @@
 #  [*db_max_pool_size*]    - Max DB Pool size for Mistral Connections
 #  [*db_max_overflow*]     - Max DB overload for Mistral Connections
 #  [*db_pool_recycle*]     - DB Pool recycle time
-#  [*api_url*]             -
-#  [*api_port*]            -
+#  [*api_url*]             - URI of Mistral backend (e.x.: http://localhost)
+#  [*api_port*]            - Port of Mistral backend. (Default: 8989)
 #
 # === Examples
 #

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -72,7 +72,7 @@ class st2::profile::mistral(
     mode   => '0755',
   }
 
-  vcsrepo { $_git_root:
+  vcsrepo { $_mistral_root:
     ensure   => present,
     source   => 'https://github.com/StackStorm/mistral.git',
     revision => $git_branch,

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -13,6 +13,8 @@
 #  [*db_max_pool_size*]    - Max DB Pool size for Mistral Connections
 #  [*db_max_overflow*]     - Max DB overload for Mistral Connections
 #  [*db_pool_recycle*]     - DB Pool recycle time
+#  [*api_url*]             -
+#  [*api_port*]            -
 #
 # === Examples
 #
@@ -34,6 +36,8 @@ class st2::profile::mistral(
   $db_max_pool_size    = '100',
   $db_max_overflow     = '400',
   $db_pool_recycle     = '3600',
+  $api_url             = $::st2::mistral_api_url,
+  $api_port            = $::st2::mistral_api_port,
 ) inherits st2 {
   include '::st2::dependencies'
 
@@ -253,6 +257,25 @@ class st2::profile::mistral(
     require     => [
       Vcsrepo[$_mistral_root],
     ],
+  }
+
+  ### Set Mistral API Settings. Useful when setting up uWSGI or other server
+  if $api_url and $api_port {
+    ini_setting { 'mistral_api_host':
+      ensure  => present,
+      path    => '/etc/mistral/mistral.conf',
+      section => 'api',
+      setting => 'host',
+      value   => $::st2::mistral_api_url,
+    }
+
+    ini_setting { 'mistral_api_port':
+      ensure  => present,
+      path    => '/etc/mistral/mistral.conf',
+      section => 'api',
+      setting => 'port',
+      value   => $::st2::mistral_api_port,
+    }
   }
 
   ### Mistral Init Scripts ###

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR adds the ability to manage Mistral service, and change the configuration for Mistral to point to alternate endpoints to communicate with the backend.

This is essential to allow management of the service via a WSGI server or other mechanism.