### PR TITLE
Manipulate K/V Store

### DIFF
--- a/manifests/kv.pp
+++ b/manifests/kv.pp
@@ -1,0 +1,37 @@
+# == Define: st2::kv
+#
+#  Sets a value to the StackStorm Key/Value Store
+#
+# === Parameters
+#  [*key*]   - Key to set
+#  [*value*] - Value of key
+#
+# === Examples
+#
+#  st2::kv { 'install_uuid':
+#    value => $_uuid,
+#  }
+#
+#
+define st2::kv {
+  $ensure   = present,
+  $key      = $name,
+  $value,
+) {
+  include ::st2
+  $_ng_init = $::st2::ng_init
+
+  exec { "set-st2-key-${key}":
+    command     => "st2 key set ${key} ${value}",
+    unless      => "st2 key get ${key}",
+    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
+    tries       => '5',
+    try_sleep   => '10',
+  }
+
+  if $_ng_init {
+    Service<| tag == 'st2::profile::service' |> -> Exec["set-st2-key-${key}"]
+  } else {
+    Exec['start st2'] -> Exec["set-st2-key-${key}"]
+  }
+}

--- a/manifests/kv.pp
+++ b/manifests/kv.pp
@@ -13,7 +13,7 @@
 #  }
 #
 #
-define st2::kv {
+define st2::kv (
   $ensure   = present,
   $key      = $name,
   $value,
@@ -23,7 +23,7 @@ define st2::kv {
 
   exec { "set-st2-key-${key}":
     command     => "st2 key set ${key} ${value}",
-    unless      => "st2 key get ${key}",
+    unless      => "st2 key get ${key} | grep ${key}",
     path        => '/usr/sbin:/usr/bin:/sbin:/bin',
     tries       => '5',
     try_sleep   => '10',

--- a/manifests/kvs.pp
+++ b/manifests/kvs.pp
@@ -1,0 +1,18 @@
+# == Class: st2::kvs
+#
+#  Automatically loads Key/Value pairs for StackStorm DB from Hiera
+#
+#  See st2::kv
+#
+# === Parameters
+#
+#  This class takes no parameters
+#
+# === Examples
+#
+#  include st2::kvs
+#
+class st2::kvs {
+  $_kvs = hiera_hash('st2::kvs', {})
+  create_resources('st2::kv', $_kvs)
+}

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -41,4 +41,5 @@ class st2::profile::fullinstall inherits st2 {
   -> class { '::st2::stanley': }
 
   include ::st2::packs
+  include ::st2::kvs
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR creates a model that allows users to set StackStorm K/V pairs via Puppet. Useful for setting permanent state.