### PR TITLE
Toggle Autoupdate

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,8 +30,8 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.12.2',
-  $revision           = '6',
+  $version            = '0.12.1',
+  $revision           = '5',
   $autoupdate         = false,
   $mistral_git_branch = 'st2-0.9.0',
   $api_url            = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 # === Parameters
 #
 #  [*version*]            - Version of StackStorm to install
+#  [*autoupdate*]         - Automatically update to latest stable. (default: false)
 #  [*revision*]           - Revision of StackStorm to install
 #  [*mistral_git_branch*] - Tagged branch of Mistral to download/install
 #  [*api_url*]            - URL where the StackStorm API lives (default: undef)
@@ -29,7 +30,8 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = st2_latest_stable(),
+  $version            = '0.12.2',
+  $autoupdate         = false,
   $revision           = undef,
   $mistral_git_branch = 'st2-0.9.0',
   $api_url            = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,8 @@
 # === Parameters
 #
 #  [*version*]            - Version of StackStorm to install
-#  [*autoupdate*]         - Automatically update to latest stable. (default: false)
 #  [*revision*]           - Revision of StackStorm to install
+#  [*autoupdate*]         - Automatically update to latest stable. (default: false)
 #  [*mistral_git_branch*] - Tagged branch of Mistral to download/install
 #  [*api_url*]            - URL where the StackStorm API lives (default: undef)
 #  [*auth*]               - Toggle to enable/disable auth (Default: false)
@@ -31,8 +31,8 @@
 #
 class st2(
   $version            = '0.12.2',
+  $revision           = '6',
   $autoupdate         = false,
-  $revision           = undef,
   $mistral_git_branch = 'st2-0.9.0',
   $api_url            = undef,
   $auth               = true,

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -25,6 +25,7 @@
 #
 class st2::profile::client (
   $version     = $::st2::version,
+  $autoupdate  = $::st2::autoupdate,
   $revision    = $::st2::revision,
   $api_url     = $::st2::cli_api_url,
   $auth_url    = $::st2::cli_auth_url,
@@ -36,6 +37,10 @@ class st2::profile::client (
   $debug       = $::st2::cli_debug,
   $cache_token = $::st2::cli_cache_token,
 ) inherits ::st2 {
+  $_version = $autoupdate ? {
+    true    => st2_latest_stable(),
+    default => $version,
+  }
 
   include '::st2::notices'
   include '::st2::params'
@@ -52,7 +57,7 @@ class st2::profile::client (
   st2::dependencies::install { $_client_dependencies: }
 
   st2::package::install { $_client_packages:
-    version  => $version,
+    version  => $_version,
   }
 
   ### This should be a versioned download too... currently on master

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -58,6 +58,7 @@ class st2::profile::client (
 
   st2::package::install { $_client_packages:
     version  => $_version,
+    revision => $revision,
   }
 
   ### This should be a versioned download too... currently on master

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -43,7 +43,7 @@ class st2::profile::client (
   }
   $_bootstrapped = $::st2client_bootstrapped ? {
     undef   => false,
-    default => str2bool($::st2client_bootstrapped),
+    default => true,
   }
 
   include '::st2::notices'

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -41,6 +41,10 @@ class st2::profile::client (
     true    => st2_latest_stable(),
     default => $version,
   }
+  $_bootstrapped = $::st2client_bootstrapped ? {
+    undef   => false,
+    default => str2bool($::st2client_bootstrapped),
+  }
 
   include '::st2::notices'
   include '::st2::params'
@@ -62,14 +66,27 @@ class st2::profile::client (
   }
 
   ### This should be a versioned download too... currently on master
-  wget::fetch { 'Download st2client requirements.txt':
-    source      => 'https://raw.githubusercontent.com/StackStorm/st2/master/st2client/requirements.txt',
-    cache_dir   => '/var/cache/wget',
-    destination => '/tmp/st2client-requirements.txt',
+  ## Only attempt to download this if the server has been appropriately bootstrapped.
+  if $autoupdate or ! $_bootstrapped {
+    wget::fetch { 'Download st2client requirements.txt':
+      source      => 'https://raw.githubusercontent.com/StackStorm/st2/master/st2client/requirements.txt',
+      cache_dir   => '/var/cache/wget',
+      destination => '/tmp/st2client-requirements.txt',
+      before      => Python::Requirements['/tmp/st2client-requirements.txt'],
+    }
   }
 
   python::requirements { '/tmp/st2client-requirements.txt':
-    require => Wget::Fetch['Download st2client requirements.txt'],
+    notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
+  }
+
+  # Once the system is properly bootstrapped, leave a breadcrumb for future runs
+  file { '/etc/facter/facts.d/st2client_bootstrapped.txt':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'st2client_bootstrapped=true',
   }
 
   file { '/root/.st2':

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -97,6 +97,17 @@ class st2::profile::mistral(
         Exec['setup mistral database'],
       ],
     }
+    vcsrepo { '/etc/mistral/actions/st2mistral':
+      ensure => $_update_vcsroot,
+      source => 'https://github.com/StackStorm/st2mistral.git',
+      revision => $git_branch,
+      provider => 'git',
+      require  => File['/etc/mistral/actions'],
+      before   => [
+        Exec['setup mistral'],
+        Exec['setup st2mistral plugin'],
+      ],
+    }
   }
 
   file { '/etc/mistral/wf_trace_logging.conf':
@@ -107,17 +118,6 @@ class st2::profile::mistral(
     source  => 'puppet:///modules/st2/etc/mistral/wf_trace_logging.conf',
   }
 
-  vcsrepo { '/etc/mistral/actions/st2mistral':
-    ensure => $_update_vcsroot,
-    source => 'https://github.com/StackStorm/st2mistral.git',
-    revision => $git_branch,
-    provider => 'git',
-    require  => File['/etc/mistral/actions'],
-    before   => [
-      Exec['setup mistral'],
-      Exec['setup st2mistral plugin'],
-    ],
-  }
   ### END Mistral Downloads ###
 
   ### Bootstrap Python ###

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -49,7 +49,7 @@ class st2::profile::mistral(
   $_mistral_root = '/opt/openstack/mistral'
   $_bootstrapped = $::mistral_bootstrapped ? {
     undef   => false,
-    default => str2bool($::mistral_bootstrapped)
+    default => true,
   }
   $_update_vcsroot = $autoupdate ? {
     true    => 'latest',

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -27,6 +27,7 @@
 #  }
 #
 class st2::profile::mistral(
+  $autoupdate          = $::st2::autoupdate,
   $manage_mysql        = false,
   $git_branch          = $::st2::mistral_git_branch,
   $db_root_password    = 'StackStorm',
@@ -46,6 +47,10 @@ class st2::profile::mistral(
   # what current mistral code ships with st2 - jdf
 
   $_mistral_root = '/opt/openstack/mistral'
+  $_update_vcsroot = $autoupdate ? {
+    true    => 'latest',
+    default => 'present',
+  }
 
   ### Dependencies ###
   if !defined(Class['::mysql::bindings']) {
@@ -73,7 +78,7 @@ class st2::profile::mistral(
   }
 
   vcsrepo { $_mistral_root:
-    ensure   => present,
+    ensure   => $_update_vcsroot,
     source   => 'https://github.com/StackStorm/mistral.git',
     revision => $git_branch,
     provider => 'git',
@@ -93,7 +98,7 @@ class st2::profile::mistral(
   }
 
   vcsrepo { '/etc/mistral/actions/st2mistral':
-    ensure => present,
+    ensure => $_update_vcsroot,
     source => 'https://github.com/StackStorm/st2mistral.git',
     revision => $git_branch,
     provider => 'git',

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -279,7 +279,6 @@ class st2::profile::mistral(
       '/bin',
       '/sbin',
     ],
-    notify      => File['/etc/facter/facts.d/mistral_bootstrapped.txt'],
   }
 
   # Once everything is done, let the system know so we can avoid some future processing

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -58,7 +58,7 @@ class st2::profile::server (
   }
   $_bootstrapped = $::st2server_bootstrapped ? {
     undef   => false,
-    default => str2bool($::st2server_bootstrapped),
+    default => true,
   }
 
   $_server_packages = $::st2::params::st2_server_packages

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -36,6 +36,7 @@
 #
 class st2::profile::server (
   $version                = $::st2::version,
+  $autoupdate             = $::st2::autoupdate,
   $revision               = $::st2::revision,
   $auth                   = $::st2::auth,
   $workers                = $::st2::workers,
@@ -51,6 +52,11 @@ class st2::profile::server (
   include '::st2::params'
   include '::st2::dependencies'
 
+  $_version = $autoupdate ? {
+    true    => st2_latest_stable(),
+    default => $version,
+  }
+
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
   $_ng_init = $::st2::ng_init
@@ -59,7 +65,7 @@ class st2::profile::server (
     'Debian' => '/usr/lib/python2.7/dist-packages',
     'RedHat' => '/usr/lib/python2.7/site-packages',
   }
-  $_register_command = $version ? {
+  $_register_command = $_version ? {
     /^0.8/  => "${_python_pack}/st2common/bin/registercontent.py",
     default => "${_python_pack}/st2common/bin/st2-register-content",
   }
@@ -88,7 +94,7 @@ class st2::profile::server (
   }
 
   st2::package::install { $_server_packages:
-    version     => $version,
+    version     => $_version,
     revision    => $revision,
     notify      => Exec['register st2 content'],
   }

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -109,6 +109,15 @@ class st2::profile::server (
     command     => "python ${_register_command} --register-all --config-file ${_conf_dir}/st2.conf",
     path        => '/usr/bin:/usr/sbin:/bin:/sbin',
     refreshonly => true,
+    notify      => File['/etc/facter/facts.d/st2server_bootstrapped.txt'],
+  }
+
+  file { '/etc/facter/facts.d/st2server_bootstrapped.txt':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    content => 'st2server_bootstrapped=true',
   }
 
   ini_setting { 'api_listen_ip':

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -25,8 +25,8 @@ class st2::profile::web(
   $version    = $::st2::version,
   $autoupdate = $::st2::autoupdate,
 ) inherits st2 {
-  $_version = $autoupdate {
-    true    => st2_latest_version(),
+  $_version = $autoupdate ? {
+    true    => st2_latest_stable(),
     default => $version,
   }
 

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -19,11 +19,17 @@
 #  include ::nginx
 #
 class st2::profile::web(
-  $api_url  = $::st2::api_url,
-  $auth     = $::st2::auth,
-  $auth_url = $::st2::auth_url,
-  $version  = $::st2::version,
+  $api_url    = $::st2::api_url,
+  $auth       = $::st2::auth,
+  $auth_url   = $::st2::auth_url,
+  $version    = $::st2::version,
+  $autoupdate = $::st2::autoupdate,
 ) inherits st2 {
+  $_version = $autoupdate {
+    true    => st2_latest_version(),
+    default => $version,
+  }
+
   file { [
       '/opt/stackstorm/static',
       '/opt/stackstorm/static/webui',
@@ -35,7 +41,7 @@ class st2::profile::web(
   }
 
   wget::fetch { 'st2web':
-    source      => "http://downloads.stackstorm.net/releases/st2/${version}/webui/webui-${version}.tar.gz",
+    source      => "http://downloads.stackstorm.net/releases/st2/${_version}/webui/webui-${_version}.tar.gz",
     cache_dir   => '/var/cache/wget',
     destination => '/tmp/st2web.tar.gz',
     before      => Exec['extract webui'],


### PR DESCRIPTION
This PR updates the puppet module to enable auto-updates for StackStorm, and disallow updates when offline. These flags will be used to setup offline VMDK/AMI.

The downside to this is now the default behavior is to increment the StackStorm version on release for this repository, but this should not be a huge issue.