### PR TITLE
Original sort was broken so fixed with a somewhat stabler sort

### DIFF
--- a/lib/puppet/parser/functions/st2_latest_stable.rb
+++ b/lib/puppet/parser/functions/st2_latest_stable.rb
@@ -3,6 +3,11 @@ require 'open-uri'
 module Puppet::Parser::Functions
   newfunction(:st2_latest_stable, :type => :rvalue) do |args|
      page = open("https://downloads.stackstorm.net/deb/pool/trusty_stable/main/s/st2api/").read
-     page.split.select { |x| x =~ /href=\"st2api/ }.collect { |x| x.scan(/>(.*)</) }.flatten.collect { |x| x.scan(/_(.*)-/).first[0] }.sort_by { |x| x.split('.')[2].to_i * -1 }.sort_by { |x| x.split('.')[1].to_i * -1}.sort_by { |x| x.split('.')[0].to_i * -1}.first
+     all_versions = page.split.select { |x| x =~ /href=\"st2api/ }.collect { |x| x.scan(/>(.*)</) }.flatten.collect { |x| x.scan(/_(.*)-/).first[0] }
+     max_major = all_versions.max{|a, b| a.split('.')[0].to_i <=> b.split('.')[0].to_i}.split('.')[0]
+     reduced_versions = all_versions.find_all{|x| x.split('.')[0] == max_major}
+     max_minor = reduced_versions.max{|a, b| a.split('.')[1].to_i <=> b.split('.')[1].to_i}.split('.')[1]
+     reduced_versions = all_versions.find_all{|x| x.split('.')[1] == max_minor}
+     reduced_versions.max{|a, b| a.split('.')[2].to_i <=> b.split('.')[2].to_i}
   end
 end


### PR DESCRIPTION
* The original sort looks ok but it acts very strange on the minor and patch values
* The new sort is not as elegant but it works reliably.

With the previous sort even with ["0.11.0", "0.11.1", "0.11.2", "0.11.2", "0.11.3", "0.11.4", "0.11.5", "0.11.6", "0.12.0", "0.12.1", "0.12.2", "0.8.3", "0.9.0", "0.9.0", "0.9.1", "0.9.2"]
it would return 0.12.1 as highest. The new one does the right sort.