### PR TITLE
Align git tag of repositories to version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.12.2',
+  $version            = '0.13.0',
   $revision           = '6',
   $autoupdate         = false,
   $mistral_git_branch = 'st2-0.13.0',

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -49,6 +49,10 @@ class st2::profile::client (
     undef   => false,
     default => true,
   }
+  $_git_tag = $_version ? {
+    /dev/   => 'master',
+    default => "v${_version}",
+  }
 
   include '::st2::notices'
   include '::st2::params'
@@ -73,7 +77,7 @@ class st2::profile::client (
   ## Only attempt to download this if the server has been appropriately bootstrapped.
   if $autoupdate or ! $_bootstrapped {
     wget::fetch { 'Download st2client requirements.txt':
-      source      => 'https://raw.githubusercontent.com/StackStorm/st2/master/st2client/requirements.txt',
+      source      => "https://raw.githubusercontent.com/StackStorm/st2/${_git_tag}/st2client/requirements.txt",
       cache_dir   => '/var/cache/wget',
       destination => '/tmp/st2client-requirements.txt',
       before      => Python::Requirements['/tmp/st2client-requirements.txt'],

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -54,7 +54,7 @@ class st2::profile::mistral(
 
   $_st2_version = $autoupdate ? {
     undef   => st2_latest_stable(),
-    default => $st2_version
+    default => $st2_version,
   }
   $_git_branch = $autoupdate ? {
     undef   => "v${_st2_version}",

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -33,6 +33,7 @@
 #
 class st2::profile::mistral(
   $autoupdate          = $::st2::autoupdate,
+  $st2_version         = $::st2::version,
   $manage_postgresql   = false,
   $git_branch          = $::st2::mistral_git_branch,
   $db_root_password    = fqdn_rand_string(32),
@@ -50,6 +51,15 @@ class st2::profile::mistral(
   $disable_engine      = false,
 ) inherits st2 {
   include '::st2::dependencies'
+
+  $_st2_version = $autoupdate ? {
+    undef   => st2_latest_stable(),
+    default => $st2_version
+  }
+  $_git_branch = $autoupdate ? {
+    undef   => "v${_st2_version}",
+    default => $git_branch,
+  }
 
   # This needs a bit more modeling... need to understand
   # what current mistral code ships with st2 - jdf
@@ -106,7 +116,7 @@ class st2::profile::mistral(
   vcsrepo { $_mistral_root:
     ensure   => $_update_vcsroot,
     source   => 'https://github.com/StackStorm/mistral.git',
-    revision => $git_branch,
+    revision => $_git_branch,
     provider => 'git',
     require  => File['/opt/openstack'],
     before   => $_mistral_root_before,
@@ -114,7 +124,7 @@ class st2::profile::mistral(
   vcsrepo { '/etc/mistral/actions/st2mistral':
     ensure => $_update_vcsroot,
     source => 'https://github.com/StackStorm/st2mistral.git',
-    revision => $git_branch,
+    revision => $_git_branch,
     provider => 'git',
     require  => File['/etc/mistral/actions'],
     before   => $_st2mistral_before,
@@ -152,7 +162,7 @@ class st2::profile::mistral(
 
   python::pip { 'python-mistralclient':
     ensure => present,
-    url    => "git+https://github.com/StackStorm/python-mistralclient.git@${git_branch}",
+    url    => "git+https://github.com/StackStorm/python-mistralclient.git@${_git_branch}",
     before   => [
       Exec['setup mistral'],
       Exec['setup st2mistral plugin'],

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -73,6 +73,10 @@ class st2::profile::server (
     true    => undef,
     default => $revision,
   }
+  $_git_tag = $_version ? {
+    /dev/   => "master",
+    default => "v${_version}",
+  }
 
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
@@ -105,7 +109,7 @@ class st2::profile::server (
   ### This should be a versioned download too... currently on master
   if $autoupdate or ! $_bootstrapped {
     wget::fetch { 'Download st2server requirements.txt':
-      source      => 'https://raw.githubusercontent.com/StackStorm/st2/master/requirements.txt',
+      source      => "https://raw.githubusercontent.com/StackStorm/st2/${_git_tag}/requirements.txt",
       cache_dir   => '/var/cache/wget',
       destination => '/tmp/st2server-requirements.txt',
       before      => Python::Requirements['/tmp/st2server-requirements.txt'],


### PR DESCRIPTION
This PR modifies the `client`, `server`, and `mistral` profiles for StackStorm to pull branches/dependencies from the appropriately tagged commit for a given version.

/cc @manasdk @m4dcoder 