### PR TITLE
Bump default version to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.7.7 (Aug 29, 2015)
+
+* Bump default StackStorm version to 0.13.1 (*upgrade*)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,10 +35,10 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.13.0',
-  $revision           = '6',
+  $version            = '0.13.1',
+  $revision           = '4',
   $autoupdate         = false,
-  $mistral_git_branch = 'st2-0.13.0',
+  $mistral_git_branch = 'st2-0.13.1',
   $api_url            = undef,
   $auth               = true,
   $auth_url           = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR bumps the default version of StackStorm to `0.13.1` after yesterday's release.