### PR TITLE
Stanley User Adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.8 (Aug 30, 2015)
+* Allow user to adjust username of 'st2::stanley' resource (*improvement*)
+
 ## 0.7.7 (Aug 29, 2015)
 
 * Bump default StackStorm version to 0.13.1 (*upgrade*)

--- a/manifests/stanley.pp
+++ b/manifests/stanley.pp
@@ -24,6 +24,7 @@
 #  include ::st2::stanley
 #
 class st2::stanley (
+  $username        = 'stanley',
   $ssh_public_key  = undef,
   $ssh_key_type    = undef,
   $ssh_private_key = undef,
@@ -47,7 +48,7 @@ class st2::stanley (
     notify { '[st2::stanley] WARNING: this class has been setup with insecure default keys for testing purposes. Please refer to Class[st2] to learn more on configuring this for production use': }
   }
 
-  st2::user { 'stanley':
+  st2::user { $username:
     client            => $client,
     server            => $server,
     create_sudo_entry => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
Via the `st2installer`, user will provide a value they want for their `stanley` user, essentially the SSH account that will be used to execute commands around a computing environment.

`st2installer` passes in `st2::stanley::username`, which is promptly ignored today. This changes that.