### PR TITLE
fix path for st2auth logger config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.9 (Sept 1, 2015)
+* Fix path for logging config with st2auth subsystem (*bugfix*)
+
 ## 0.7.8 (Aug 30, 2015)
 * Allow user to adjust username of 'st2::stanley' resource (*improvement*)
 

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -215,7 +215,7 @@ class st2::profile::server (
     path   => '/etc/st2/st2.conf',
     section => 'auth',
     setting => 'logging',
-    value   => "/etc/st2api/${_logger_config}.conf",
+    value   => "/etc/st2auth/${_logger_config}.conf",
   }
 
   ## Notifier Settings

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the path to the logger config for `st2auth`. Found while trying to debug why st2api and st2auth logs are empty in st2workroom.
