### PR TITLE
Stop restarting StackStorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## In Development
+* Stop `st2::pack` resource restarting StackStorm (*improvement*)
+
 ## 0.7.10 (Sept 2, 2015)
-*Fix `manage_mysql` -> `manage_postgresql` in st2::profile::server (*bugfix*)
+* Fix `manage_mysql` -> `manage_postgresql` in st2::profile::server (*bugfix*)
 * Fix error with stanley user UID change (*bugfix*)
 
 ## 0.7.9 (Sept 1, 2015)

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -52,16 +52,10 @@ define st2::pack (
   }
 
   if $_ng_init {
-    Service<| tag == 'st2::profile::service' |> -> Exec["install-st2-pack-${name}"] -> Exec['restart-st2']
+    Service<| tag == 'st2::profile::service' |> -> Exec["install-st2-pack-${name}"]
   } else {
-    Exec['start st2'] -> Exec["install-st2-pack-${pack}"] -> Exec['restart-st2']
+    Exec['start st2'] -> Exec["install-st2-pack-${pack}"]
   }
-
-  ensure_resource('exec', 'restart-st2', {
-    'command'     => 'st2ctl restart',
-    'path'        => '/usr/sbin:/usr/bin:/sbin:/bin',
-    'refreshonly' => true,
-  })
 
   if $config {
     validate_hash($config)


### PR DESCRIPTION
In the past, the `st2::pack` resource would try and restart StackStorm as part of a pack installation. However, StackStorm pack installation no longer needs a helping hand, and can handle restarting of components on its own.