### PR TITLE
Environment Variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@
 #  [*cli_password*]       - CLI config - Auth Password
 #  [*cli_api_url*]        - CLI config - API URL
 #  [*cli_auth_url*]       - CLI config - Auth URL
+#  [*global_env*]         - Globally set the environment variables for ST2 API/Auth
+#                           Overwritten by local config or CLI arguments.
 #  [*workers*]            - Set the number of actionrunner processes to start
 #  [*ng_init*]            - [Experimental] Init scripts for services. Upstart ONLY
 #  [*syslog*]             - Routes all log messages to syslog
@@ -51,6 +53,7 @@ class st2(
   $cli_password       = fqdn_rand_string(32),
   $cli_api_url        = 'http://localhost:9101',
   $cli_auth_url       = 'http://localhost:9100',
+  $global_env         = false,
   $workers            = 8,
   $ng_init            = false,
   $mistral_api_url    = undef,

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -36,6 +36,7 @@ class st2::profile::client (
   $cacert      = $::st2::cli_cacert,
   $debug       = $::st2::cli_debug,
   $cache_token = $::st2::cli_cache_token,
+  $global_env  = $::st2::global_env,
 ) inherits ::st2 {
   $_version = $autoupdate ? {
     true    => st2_latest_stable(),
@@ -102,6 +103,17 @@ class st2::profile::client (
     owner  => 'root',
     group  => 'root',
     mode   => '0700',
+  }
+
+  # Setup global environment variables:
+  if $global_env {
+    file { '/etc/profile.d/st2.sh':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template('st2/etc/profile.d/st2.sh.erb'),
+    }
   }
 
   Ini_setting {

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -24,6 +24,7 @@
 #  include st2::profile::client
 #
 class st2::profile::client (
+  $auth        = $::st2::auth,
   $version     = $::st2::version,
   $autoupdate  = $::st2::autoupdate,
   $revision    = $::st2::revision,
@@ -60,12 +61,6 @@ class st2::profile::client (
 
   $_client_packages = $st2::params::st2_client_packages
   $_client_dependencies = $st2::params::debian_client_dependencies
-
-  $_auth = $::st2::auth
-  $_api_url = $::st2::api_url
-  $_auth_url = $::st2::auth_url
-  $_cli_username = $::st2::cli_username
-  $_cli_password = $::st2::cli_password
 
   st2::dependencies::install { $_client_dependencies: }
 
@@ -162,7 +157,7 @@ class st2::profile::client (
     value   => $_cache_token,
   }
 
-  if $_auth {
+  if $auth {
     ini_setting { 'st2_cli_credentials_username':
       section => 'credentials',
       setting => 'username',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",

--- a/templates/etc/profile.d/st2.sh.erb
+++ b/templates/etc/profile.d/st2.sh.erb
@@ -1,0 +1,6 @@
+<%- if @_api_url -%>
+ST2_API_URL=<%= @_api_url %>
+<%- end -%>
+<%- if @_auth_url -%>
+ST2_AUTH_URL=<%= @_auth_url %>
+<%- end -%>

--- a/templates/etc/profile.d/st2.sh.erb
+++ b/templates/etc/profile.d/st2.sh.erb
@@ -1,6 +1,2 @@
-<%- if @_api_url -%>
 ST2_API_URL=<%= @_api_url %>
-<%- end -%>
-<%- if @_auth_url -%>
 ST2_AUTH_URL=<%= @_auth_url %>
-<%- end -%>

--- a/templates/etc/profile.d/st2.sh.erb
+++ b/templates/etc/profile.d/st2.sh.erb
@@ -1,2 +1,4 @@
 ST2_API_URL=<%= @api_url %>
 ST2_AUTH_URL=<%= @auth_url %>
+
+export ST2_API_URL ST2_AUTH_URL

--- a/templates/etc/profile.d/st2.sh.erb
+++ b/templates/etc/profile.d/st2.sh.erb
@@ -1,2 +1,2 @@
-ST2_API_URL=<%= @_api_url %>
-ST2_AUTH_URL=<%= @_auth_url %>
+ST2_API_URL=<%= @api_url %>
+ST2_AUTH_URL=<%= @auth_url %>


### PR DESCRIPTION
This PR updates StackStorm to add an option to the `st2::profile::client` class to optionally enable global environment variables for StackStorm. This is good for the AIO installer or other nodes where we're doing a bunch of pre-config for users.

Also a good way to standardize clients across a fleet.