### PR TITLE
bumping to StackStorm v0.13.2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,8 +37,8 @@
 #    st2::revison: 11
 #
 class st2(
-  $version            = '0.13.1',
-  $revision           = '4',
+  $version            = '0.13.2',
+  $revision           = '5',
   $autoupdate         = false,
   $mistral_git_branch = 'st2-0.13.1',
   $api_url            = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.7.11",
+  "version": "0.8.0",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the module to use StackStorm 0.13.2 as the default release.