### PR TITLE
abstract st2::client::settings to defined type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## In Development
+## Under Development
+* Configure st2client CLI settings for any user (*improvement*)
+
+## 0.8.0 (Sept 10, 2015)
+* Release StackStorm v0.13.2
 * Stop `st2::pack` resource restarting StackStorm (*improvement*)
 
 ## 0.7.10 (Sept 2, 2015)

--- a/manifests/client/settings.pp
+++ b/manifests/client/settings.pp
@@ -1,0 +1,103 @@
+# Definition: st2::client::settings
+#
+#  This defined type generates a configuration file for the
+#  st2client CLI to know where to access StackStorm
+#
+# Variables
+#
+#  [*base_url*]    - CLI config - Base URL lives
+#  [*api_version*] - CLI config - API Version
+#  [*debug*]       - CLI config - Enable/Disable Debug
+#  [*cache_token*] - CLI config - True to cache auth token until expries
+#  [*username*]    - CLI config - Auth Username
+#  [*password*]    - CLI config - Auth Password
+#  [*api_url*]     - CLI config - API URL
+#  [*auth_url*]    - CLI config - Auth URL
+#
+define st2::client::settings(
+  $user                = $name,
+  $homedir             = "/home/${name}",
+  $auth                = $::st2::auth,
+  $api_url             = $::st2::cli_api_url,
+  $auth_url            = $::st2::cli_auth_url,
+  $base_url            = $::st2::cli_base_url,
+  $username            = $::st2::cli_username,
+  $password            = $::st2::cli_password,
+  $disable_credentials = false,
+  $api_version         = $::st2::cli_api_version,
+  $cacert              = $::st2::cli_cacert,
+  $debug               = $::st2::cli_debug,
+  $cache_token         = $::st2::cli_cache_token,
+) {
+  Ini_setting {
+    ensure  => present,
+    path    => "${homedir}/.st2/config",
+    require => File["${homedir}/.st2"],
+  }
+
+  file { "${homedir}/.st2":
+    ensure => directory,
+    owner  => $user,
+    mode   => '0700',
+  }
+
+  ini_setting { "${user}-st2_cli_api_url":
+    section => 'api',
+    setting => 'url',
+    value   => $api_url,
+  }
+  ini_setting { "${user}-st2_cli_general_base_url":
+    section => 'general',
+    setting => 'base_url',
+    value   => $base_url,
+  }
+  ini_setting { "${user}-st2_cli_general_api_version":
+    section => 'general',
+    setting => 'api_version',
+    value   => $api_version,
+  }
+  ini_setting { "${user}-st2_cli_general_cacert":
+    section => 'general',
+    setting => 'cacert',
+    value   => $cacert,
+  }
+
+  $_cli_debug = $debug ? {
+    true    => 'True',
+    default => 'False',
+  }
+  ini_setting { "${user}-st2_cli_cli_debug":
+    section => 'cli',
+    setting => 'debug',
+    value   => $_cli_debug,
+  }
+  $_cache_token = $cache_token ? {
+    true    => 'True',
+    default => 'False',
+  }
+  ini_setting { "${user}-st2_cli_cache_token":
+    section => 'cli',
+    setting => 'cache_token',
+    value   => $_cache_token,
+  }
+
+  if $auth {
+    if ! $disable_credentials {
+      ini_setting { "${user}-st2_cli_credentials_username":
+        section => 'credentials',
+        setting => 'username',
+        value   => $username,
+      }
+      ini_setting { "${user}-st2_cli_credentials_password":
+        section => 'credentials',
+        setting => 'password',
+        value   => $password,
+      }
+    }
+    ini_setting { "${user}-st2_cli_auth_url":
+      section => 'auth',
+      setting => 'url',
+      value   => $auth_url,
+    }
+  }
+}

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -84,6 +84,21 @@ class st2::profile::client (
     notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
   }
 
+  # Setup st2client settings for Root user by default
+  st2::client::settings { 'root':
+    homedir     => '/root',
+    auth        => $auth,
+    api_url     => $api_url,
+    auth_url    => $auth_url,
+    base_url    => $base_url,
+    username    => $username,
+    password    => $password,
+    api_version => $api_version,
+    cacert      => $cacert,
+    debug       => $debug,
+    cache_token => $cache_token,
+  }
+
   # Once the system is properly bootstrapped, leave a breadcrumb for future runs
   file { '/etc/facter/facts.d/st2client_bootstrapped.txt':
     ensure  => file,
@@ -91,13 +106,6 @@ class st2::profile::client (
     group   => 'root',
     mode    => '0444',
     content => 'st2client_bootstrapped=true',
-  }
-
-  file { '/root/.st2':
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0700',
   }
 
   # Setup global environment variables:
@@ -108,70 +116,6 @@ class st2::profile::client (
       group   => 'root',
       mode    => '0755',
       content => template('st2/etc/profile.d/st2.sh.erb'),
-    }
-  }
-
-  Ini_setting {
-    ensure  => present,
-    path    => '/root/.st2/config',
-    require => File['/root/.st2'],
-  }
-
-  ini_setting { 'st2_cli_api_url':
-    section => 'api',
-    setting => 'url',
-    value   => $api_url,
-  }
-  ini_setting { 'st2_cli_general_base_url':
-    section => 'general',
-    setting => 'base_url',
-    value   => $base_url,
-  }
-  ini_setting { 'st2_cli_general_api_version':
-    section => 'general',
-    setting => 'api_version',
-    value   => $api_version,
-  }
-  ini_setting { 'st2_cli_general_cacert':
-    section => 'general',
-    setting => 'cacert',
-    value   => $cacert,
-  }
-
-  $_cli_debug = $debug ? {
-    true    => 'True',
-    default => 'False',
-  }
-  ini_setting { 'st2_cli_cli_debug':
-    section => 'cli',
-    setting => 'debug',
-    value   => $_cli_debug,
-  }
-  $_cache_token = $cache_token ? {
-    true    => 'True',
-    default => 'False',
-  }
-  ini_setting { 'st2_cli_cache_token':
-    section => 'cli',
-    setting => 'cache_token',
-    value   => $_cache_token,
-  }
-
-  if $auth {
-    ini_setting { 'st2_cli_credentials_username':
-      section => 'credentials',
-      setting => 'username',
-      value   => $username,
-    }
-    ini_setting { 'st2_cli_credentials_password':
-      section => 'credentials',
-      setting => 'password',
-      value   => $password,
-    }
-    ini_setting { 'st2_cli_auth_url':
-      section => 'auth',
-      setting => 'url',
-      value   => $auth_url,
     }
   }
 }


### PR DESCRIPTION
This PR abstracts the config settings defined previously in
::st2::profile::client into a new defined type, ::st2::client::settings,
that can be used to generate CLI configuration for any user.