### PR TITLE
Don't require wget for python requirements

### DIFF
--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -76,6 +76,10 @@ class st2::profile::client (
       source      => "https://raw.githubusercontent.com/StackStorm/st2/${_git_tag}/st2client/requirements.txt",
       cache_dir   => '/var/cache/wget',
       destination => '/tmp/st2client-requirements.txt'
+      before      => [
+        Python::Requirements['/tmp/st2client-requirements.txt'],
+        Exec['pip27_install_st2client_reqs']
+      ]
     }
   }
 
@@ -84,7 +88,6 @@ class st2::profile::client (
     'Debian': {
       python::requirements { '/tmp/st2client-requirements.txt':
         notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
-        require => Wget::Fetch['Download st2client requirements.txt']
       }
     }
     'RedHat': {
@@ -93,12 +96,10 @@ class st2::profile::client (
           path    => '/usr/bin:/usr/sbin:/bin:/sbin',
           command => 'pip2.7 install -U -r /tmp/st2client-requirements.txt',
           notify  => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
-          require => Wget::Fetch['Download st2client requirements.txt']
         }
       } else {
         python::requirements { '/tmp/st2client-requirements.txt':
           notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
-          require => Wget::Fetch['Download st2client requirements.txt']
         }
       }
     }

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -75,7 +75,7 @@ class st2::profile::client (
     wget::fetch { 'Download st2client requirements.txt':
       source      => "https://raw.githubusercontent.com/StackStorm/st2/${_git_tag}/st2client/requirements.txt",
       cache_dir   => '/var/cache/wget',
-      destination => '/tmp/st2client-requirements.txt'
+      destination => '/tmp/st2client-requirements.txt',
       before      => [
         Python::Requirements['/tmp/st2client-requirements.txt'],
         Exec['pip27_install_st2client_reqs']

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -111,7 +111,11 @@ class st2::profile::server (
     wget::fetch { 'Download st2server requirements.txt':
       source      => "https://raw.githubusercontent.com/StackStorm/st2/${_git_tag}/requirements.txt",
       cache_dir   => '/var/cache/wget',
-      destination => '/tmp/st2server-requirements.txt'
+      destination => '/tmp/st2server-requirements.txt',
+      before      => [
+        Python::Requirements['/tmp/st2server-requirements.txt'],
+        Exec['pip27_install_st2server_reqs']
+      ]
     }
   }
 
@@ -120,7 +124,6 @@ class st2::profile::server (
     'Debian': {
       python::requirements { '/tmp/st2server-requirements.txt':
         before  => Exec['register st2 content'],
-        require => Wget::Fetch['Download st2server requirements.txt']
       }
     }
     'RedHat': {
@@ -128,13 +131,12 @@ class st2::profile::server (
         exec { 'pip27_install_st2server_reqs':
           path    => '/usr/bin:/usr/sbin:/bin:/sbin',
           command => 'pip2.7 install -U -r /tmp/st2server-requirements.txt',
+          before  => Exec['register st2 content'],
           notify  => File['/etc/facter/facts.d/st2server_bootstrapped.txt'],
-          require => Wget::Fetch['Download st2server requirements.txt']
         }
       } else {
         python::requirements { '/tmp/st2server-requirements.txt':
           before  => Exec['register st2 content'],
-          require => Wget::Fetch['Download st2server requirements.txt']
         }
       }
     }


### PR DESCRIPTION
If the install of the requirements.txt files requires the wget::fetch, it fails when the *bootstrapped facts exist.