### PR TITLE
Move python-requirements into resource fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# In Development
+* Fix condition where `autoupdate: false` would result in missing resources (*bugfix*)
+
 ## 0.9.1 (Sept 17, 2015)
 * Configure WebUI to integrate with Flow (*feature*)
 * Configure st2client CLI settings for any user (*improvement*)

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -77,32 +77,33 @@ class st2::profile::client (
       cache_dir   => '/var/cache/wget',
       destination => '/tmp/st2client-requirements.txt'
     }
-  }
 
-  # More RedHat 6 hackery.  Need to use pip2.7.
-  case $::osfamily {
-    'Debian': {
-      python::requirements { '/tmp/st2client-requirements.txt':
-        notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
-        require => Wget::Fetch['Download st2client requirements.txt']
-      }
-    }
-    'RedHat': {
-      if $operatingsystemmajrelease == '6' {
-        exec { 'pip27_install_st2client_reqs':
-          path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-          command => 'pip2.7 install -U -r /tmp/st2client-requirements.txt',
-          notify  => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
-          require => Wget::Fetch['Download st2client requirements.txt']
-        }
-      } else {
+    # More RedHat 6 hackery.  Need to use pip2.7.
+    case $::osfamily {
+      'Debian': {
         python::requirements { '/tmp/st2client-requirements.txt':
           notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
           require => Wget::Fetch['Download st2client requirements.txt']
         }
       }
+      'RedHat': {
+        if $operatingsystemmajrelease == '6' {
+          exec { 'pip27_install_st2client_reqs':
+            path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+            command => 'pip2.7 install -U -r /tmp/st2client-requirements.txt',
+            notify  => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
+            require => Wget::Fetch['Download st2client requirements.txt']
+          }
+        } else {
+          python::requirements { '/tmp/st2client-requirements.txt':
+            notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
+            require => Wget::Fetch['Download st2client requirements.txt']
+          }
+        }
+      }
     }
   }
+
 
   # Setup st2client settings for Root user by default
   st2::client::settings { 'root':

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -113,32 +113,32 @@ class st2::profile::server (
       cache_dir   => '/var/cache/wget',
       destination => '/tmp/st2server-requirements.txt'
     }
-  }
-
-  # More RedHat 6 hackery.  Need to use pip2.7.
-  case $::osfamily {
-    'Debian': {
-      python::requirements { '/tmp/st2server-requirements.txt':
-        before  => Exec['register st2 content'],
-        require => Wget::Fetch['Download st2server requirements.txt']
-      }
-    }
-    'RedHat': {
-      if $operatingsystemmajrelease == '6' {
-        exec { 'pip27_install_st2server_reqs':
-          path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-          command => 'pip2.7 install -U -r /tmp/st2server-requirements.txt',
-          notify  => File['/etc/facter/facts.d/st2server_bootstrapped.txt'],
-          require => Wget::Fetch['Download st2server requirements.txt']
-        }
-      } else {
+    # More RedHat 6 hackery.  Need to use pip2.7.
+    case $::osfamily {
+      'Debian': {
         python::requirements { '/tmp/st2server-requirements.txt':
           before  => Exec['register st2 content'],
           require => Wget::Fetch['Download st2server requirements.txt']
         }
       }
+      'RedHat': {
+        if $operatingsystemmajrelease == '6' {
+          exec { 'pip27_install_st2server_reqs':
+            path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+            command => 'pip2.7 install -U -r /tmp/st2server-requirements.txt',
+            notify  => File['/etc/facter/facts.d/st2server_bootstrapped.txt'],
+            require => Wget::Fetch['Download st2server requirements.txt']
+          }
+        } else {
+          python::requirements { '/tmp/st2server-requirements.txt':
+            before  => Exec['register st2 content'],
+            require => Wget::Fetch['Download st2server requirements.txt']
+          }
+        }
+      }
     }
   }
+
 
   st2::package::install { $_server_packages:
     version     => $_version,


### PR DESCRIPTION
This commit moves all associated resources for processing
requirements.txt into the same conditional block that toggles
on and off the download based autoupdate being true or false.

Keeping the resources together repairs a condition where catalog
compilation would fail due to `autocomplete` being `false`