### PR TITLE
refresh mistral service on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.7 (Sept 22, 2015)
+* Restart mistral on init script update
+
 ## 0.9.6 (Sept 22, 2015)
 * Add ``silence_ssl_warnings`` option to the client profile.
 

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -355,6 +355,7 @@ class st2::profile::mistral(
           group  => 'root',
           mode   => '0444',
           content => template('st2/etc/init/mistral.conf.erb'),
+          notify  => Service['mistral'],
         }
       }
       'RedHat': {
@@ -366,6 +367,7 @@ class st2::profile::mistral(
               group  => 'root',
               mode   => '0444',
               content => template('st2/etc/systemd/system/mistral.service.erb'),
+              notify  => Service['mistral'],
             }
           }
           '6': {
@@ -375,6 +377,7 @@ class st2::profile::mistral(
               group  => 'root',
               mode   => '0755',
               content => template('st2/etc/init.d/mistral.erb'),
+              notify  => Service['mistral'],
             }
           }
         }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the Mistral profile to automatically restart the Mistral service anytime the mistral config is changed.

This allows service subsystem changes on the fly.