### PR TITLE
RBAC Management Defined Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.8 (Sept 25, 2015)
+* Add ability to manage StackStorm RBAC roles (*improvement*)
+
 ## 0.9.7 (Sept 22, 2015)
 * Restart mistral on init script update
 

--- a/manifests/rbac.pp
+++ b/manifests/rbac.pp
@@ -4,6 +4,15 @@
 # This is an enterprise feature, and requires a license
 # to be used.
 #
+# Example
+#
+#   st2::rbac { 'admin':
+#     description => "Administrative user",
+#     roles       => [
+#       'observer',
+#       'my_test_role',
+#     ],
+#   }
 define st2::rbac (
   $ensure      = 'present',
   $user        = $name,

--- a/manifests/rbac.pp
+++ b/manifests/rbac.pp
@@ -30,6 +30,13 @@ define st2::rbac (
     'mode'    => '0755',
     'require' => Class['::st2::profile::server'],
   })
+  ensure_resource('file', "${_rbac_dir}/roles", {
+    'ensure'  => 'directory',
+    'owner'   => 'root',
+    'group'   => 'root',
+    'mode'    => '0755',
+    'require' => Class['::st2::profile::server'],
+  })
   ensure_resource('file', "${_rbac_dir}/assignments", {
     'ensure'  => 'directory',
     'owner'   => 'root',

--- a/manifests/rbac.pp
+++ b/manifests/rbac.pp
@@ -1,0 +1,53 @@
+# Definition: st2::rbac
+#
+# This defined type creates RBAC resources for users
+# This is an enterprise feature, and requires a license
+# to be used.
+#
+define st2::rbac (
+  $ensure      = 'present',
+  $user        = $name,
+  $description = "Created and managed by Puppet",
+  $roles       = [],
+) {
+  $_rbac_dir = '/opt/stackstorm/rbac'
+  $_enabled_state = $ensure ? {
+    'present' => 'true',
+    default   => 'false',
+  }
+
+  ensure_resource('file', $_rbac_dir, {
+    'ensure'  => 'directory',
+    'owner'   => 'root',
+    'group'   => 'root',
+    'mode'    => '0755',
+    'require' => Class['::st2::profile::server'],
+  })
+  ensure_resource('file', "${_rbac_dir}/assignments", {
+    'ensure'  => 'directory',
+    'owner'   => 'root',
+    'group'   => 'root',
+    'mode'    => '0755',
+    'require' => Class['::st2::profile::server'],
+  })
+  ensure_resource('file', "${_rbac_dir}/assignments", {
+    'ensure'  => 'directory',
+    'owner'   => 'root',
+    'group'   => 'root',
+    'mode'    => '0755',
+    'require' => Class['::st2::profile::server'],
+  })
+  ensure_resource('exec', 'reload st2 rbac definitions', {
+    'cmd'         => 'st2-apply-rbac-definitions',
+    'refreshonly' => 'true',
+    'path'        => '/usr/sbin:/usr/bin:/sbin:/bin',
+  })
+  file { "${_rbac_dir}/assignments/${user}.yaml":
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('st2/rbac/assignments/user.yaml.erb'),
+    notify  => Exec['reload st2 rbac definitions'],
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",

--- a/templates/rbac/assignments/user.yaml.erb
+++ b/templates/rbac/assignments/user.yaml.erb
@@ -1,0 +1,8 @@
+---
+    username: "<%= @user %>"
+    description: "<%= @description %>"
+    enabled: <%= @_enabled_state %>
+    roles:
+<%- @roles.each do |role| -%>
+        - "<%= role %>"
+<%- end -%>


### PR DESCRIPTION
This PR adds a defined type (`st2::rbac`) to manage RBAC roles on a StackStorm system.