### PR TITLE
add ability to adjust SSH key location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.11 (Oct 1, 2015)
+* Add ability for user to change SSH key location in /etc/st2/st2.conf
+
 ## 0.9.10 (Sept 28, 2015)
 * Fix typo in RBAC type.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@
 #  [*syslog_protocol*]    - Syslog protocol. Default: udp
 #  [*syslog_port*]        - Syslog port. Default: 514
 #  [*syslog_facility*]    - Syslog facility. Default: local7
+#  [*ssh_key_location*]   - Location on filesystem of Admin SSH key for remote runner
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
 #
@@ -66,4 +67,5 @@ class st2(
   $syslog_protocol          = 'udp',
   $syslog_port              = 514,
   $syslog_facility          = 'local7',
+  $ssh_key_location         = '/home/stanley/.ssh/st2_stanley_key',
 ) {}

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -26,6 +26,7 @@
 #  [*syslog_protocol*]        - Syslog protocol.
 #  [*syslog_port*]            - Syslog port.
 #  [*syslog_facility*]        - Syslog facility.
+#  [*ssh_key_location*]       - Location on filesystem of Admin SSH key for remote runner
 #
 # === Variables
 #
@@ -56,6 +57,7 @@ class st2::profile::server (
   $manage_st2api_service  = true,
   $manage_st2auth_service = true,
   $manage_st2web_service  = true,
+  $ssh_key_location       = $::st2::ssh_key_location,
 ) inherits st2 {
   include '::st2::notices'
   include '::st2::params'
@@ -166,7 +168,7 @@ class st2::profile::server (
     path    => '/etc/st2/st2.conf',
     section => 'system_user',
     setting => 'ssh_key_file',
-    value   => '/home/stanley/.ssh/st2_stanley_key',
+    value   => $ssh_key_location,
   }
 
   ## ActionRunner settings

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR adds the ability for a user to specify where on the filesystem the SSH key is for remote runners. 