### PR TITLE
Start Postgresql before Mistral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.13 (Oct 2, 2015)
+* Ensure postgresql is setup and running before starting Mistral service.
+
 ## 0.9.12 (Oct 1, 2015)
 * Refresh services on ini setting change.
 

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -258,8 +258,11 @@ class st2::profile::mistral(
     class { '::postgresql::server':
       postgres_password => $db_root_password,
     }
-
     
+    ## This uses the Spaceship operator to call the mistral service,
+    ## to ensure there is no breakage if a user is not managing the
+    ## there is no compilation error.
+    Class['::postgresql::server'] -> Service<| tag == 'mistral' |>
 
     ### Dependencies ###
     include ::postgresql::lib::devel

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -396,6 +396,8 @@ class st2::profile::mistral(
 
     # Setup refresh events on config change for mistral
     Ini_setting<| tag == 'mistral' |> ~> Service['mistral']
+    Exec<| tag == 'mistral' |> -> Service['mistral']
+    
   }
   ### END Mistral Init Scripts ###
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR ensures that PostgreSQL stuffs is done before Mistral services are started/reloaded.