### PR TITLE
Repair mappings for Packages on RHEL 7

### DIFF
--- a/manifests/helper/service_manager.pp
+++ b/manifests/helper/service_manager.pp
@@ -5,8 +5,10 @@
 define st2::helper::service_manager (
   $process = $name,
 ) {
+  include ::st2::params
+  
   $_package_map = $::st2::params::component_map
-  $_package     = $_package_map["${process}"]
+  $_package     = $_package_map[$process]
   $_init_type   = $::st2::params::init_type
   $_subsystem   = $::st2::params::subsystem_map[$process]
 
@@ -76,11 +78,8 @@ define st2::helper::service_manager (
     hasstatus  => true,
     hasrestart => true,
     provider   => $_init_type,
-    subscribe  => [
-      Package["${_package}"],
-      Package['st2common'],
-    ],
   }
 
+  Package<| tag == 'st2::package::install' |> ~> Service[$_subsystem]
   File<| tag == 'st2::service_manager' |> ~> Service[$_subsystem]
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,13 +39,20 @@ class st2::params(
   ]
 
   $component_map = {
-    actionrunner    => 'st2actions',
-    api             => 'st2api',
-    auth            => 'st2auth',
-    notifier        => 'st2actions',
-    resultstracker  => 'st2actions',
-    rulesengine     => 'st2reactor',
-    sensorcontainer => 'st2reactor',
+    actionrunner       => 'st2actions',
+    api                => 'st2api',
+    auth               => 'st2auth',
+    notifier           => 'st2actions',
+    resultstracker     => 'st2actions',
+    rulesengine        => 'st2reactor',
+    sensorcontainer    => 'st2reactor',
+    st2actionrunner    => 'st2actions',
+    st2api             => 'st2api',
+    st2auth            => 'st2auth',
+    st2notifier        => 'st2actions',
+    st2resultstracker  => 'st2actions',
+    st2rulesengine     => 'st2reactor',
+    st2sensorcontainer => 'st2reactor',
   }
   $subsystem_map = {
     actionrunner       => 'st2actionrunner',


### PR DESCRIPTION
This PR updates the package map to include packages regardless how they are referenced, and a less restrictive resource ordering with Spaceships! :alien: