### PR TITLE
Update init script to use `su` instead of `sudo`

### DIFF
--- a/templates/etc/init.d/mistral.erb
+++ b/templates/etc/init.d/mistral.erb
@@ -33,9 +33,9 @@ case "$1" in
     else
         echo "Starting $name"
         if [ -z "$user" ]; then
-            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            su -c "$cmd" >> "$stdout_log" 2>> "$stderr_log" &
         else
-            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            su "$user" -c "$cmd" >> "$stdout_log" 2>> "$stderr_log" &
         fi
         echo $! > "$pid_file"
         if ! is_running; then


### PR DESCRIPTION
Because you cannot always assert sudo, and you cannot always assert a TTY