### PR TITLE
restart services when edits are made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.24 (Oct 15, 2015)
+* Bug fixes
+* Service restart with `Ini_setting { tag => 'st2::config' }`
+
 ## 0.9.19 (Oct 14, 2015)
 * Repair init scripts for Mistral on RHEL 6/7 and Debian
 

--- a/manifests/auth/mongodb.pp
+++ b/manifests/auth/mongodb.pp
@@ -43,6 +43,13 @@ class st2::auth::mongodb (
   }
   $_api_url = $::st2::api_url
 
+  # Defaults for st2config to ensure service refresh propagates
+  # anytime these values are changed. See profile/server.pp
+  # for more info
+  Ini_setting {
+    tag => 'st2::config',
+  }
+
   ini_setting { 'auth_mode':
     ensure  => present,
     path    => '/etc/st2/st2.conf',

--- a/manifests/auth/proxy.pp
+++ b/manifests/auth/proxy.pp
@@ -20,6 +20,13 @@ class st2::auth::proxy (
   }
   $_api_url = $::st2::api_url
 
+  # Defaults for st2config to ensure service refresh propagates
+  # anytime these values are changed. See profile/server.pp
+  # for more info
+  Ini_setting {
+    tag => 'st2::config',
+  }
+
   ini_setting { 'auth_mode':
     ensure  => present,
     path    => '/etc/st2/st2.conf',

--- a/manifests/auth/standalone.pp
+++ b/manifests/auth/standalone.pp
@@ -43,6 +43,13 @@ class st2::auth::standalone(
   $_cli_username = $::st2::cli_username
   $_cli_password = $::st2::cli_password
 
+  # Defaults for st2config to ensure service refresh propagates
+  # anytime these values are changed. See profile/server.pp
+  # for more info
+  Ini_setting {
+    tag => 'st2::config',
+  }
+
   ini_setting { 'auth_mode':
     ensure  => present,
     path    => '/etc/st2/st2.conf',

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -26,6 +26,13 @@ define st2::helper::auth_manager (
 
   # Common settings for all auth backends
 
+  # Defaults for st2config to ensure service refresh propagates
+  # anytime these values are changed. See profile/server.pp
+  # for more info
+  Ini_setting {
+    tag => 'st2::config',
+  }
+
   ini_setting { 'auth_debug':
     ensure  => present,
     path    => "${_st2_conf_file}",

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -212,6 +212,13 @@ class st2::profile::mistral(
 
 
   ### Mistral Config Modeling ###
+  # Defaults for Mistral Config to ensure service refresh propagates
+  # anytime these values are changed. See profile/mistral.pp
+  # for more info
+  Ini_setting {
+    tag => 'mistral::config',
+  }
+
   ini_setting { 'connection config':
     ensure  => present,
     path    => '/etc/mistral/mistral.conf',

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -400,4 +400,4 @@ class st2::profile::server (
 
     Exec['start st2'] -> St2::Pack<||>
   }
-
+}

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -164,6 +164,11 @@ class st2::profile::server (
     content => 'st2server_bootstrapped=true',
   }
 
+  # Sets a tag on all the Ini_setting resources
+  Ini_setting {
+    tag => 'st2::config',
+  }
+
   ini_setting { 'ssh_key_stanley':
     ensure  => present,
     path    => '/etc/st2/st2.conf',
@@ -390,9 +395,9 @@ class st2::profile::server (
     }
 
     St2::Package::Install<| tag == 'st2::profile::server' |>
-    -> Ini_setting<| tag == 'st2::profile::server' |>
+    -> Ini_setting<| tag == 'st2::config' |>
     -> Exec['start st2']
 
     Exec['start st2'] -> St2::Pack<||>
   }
-}
+

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the service refresh to look for `Ini_setting` resources that have been tagged with `st2::config`. Allows loose coupling of service restart in classes outside of the module. (for example, RBAC)