### PR TITLE
Hotfix for RHEL 6 Client Package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.2 (Oct 19. 2015)
+* Fix for RHEL 6 client package installation
+
 ## 0.10.1 (Oct 16. 2015)
 * Init scripts default install now
 

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -54,7 +54,7 @@ define st2::package::install(
         # 0.14dev.184-1 becomes 0.14.dev184-1
         # https://stackstorm.slack.com/archives/opstown/p1445224799003958
         if $::operatingsystemmajrelease == '6' and $version =~ /dev/ {
-          $_package_version = regsubst("${_version}.${_revision}-1", 'dev\.', '\.dev')
+          $_package_version = regsubst("${_version}.${_revision}-1", 'dev\.', '.dev')
         } else {
           $_package_version = "${_version}.${_revision}-1"
         }

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -53,7 +53,7 @@ define st2::package::install(
         # A very odd RHEL 6 bug we have not been able to get to the bottom of yet
         # 0.14dev.184-1 becomes 0.14.dev184-1
         # https://stackstorm.slack.com/archives/opstown/p1445224799003958
-        if $::operatingsystemmajrelease == '6' and $name =~ /dev/ {
+        if $::operatingsystemmajrelease == '6' and $version =~ /dev/ {
           $_package_version = regsubst("${_version}.${_revision}-1", 'dev\.', '\.dev')
         } else {
           $_package_version = "${_version}.${_revision}-1"

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -50,7 +50,14 @@ define st2::package::install(
       }
       # Temporary Hack while fixing build pipeline
       if $name =~ /client/ {
-        $_package_version = "${_version}.${_revision}-1"
+        # A very odd RHEL 6 bug we have not been able to get to the bottom of yet
+        # 0.14dev.184-1 becomes 0.14.dev184-1
+        # https://stackstorm.slack.com/archives/opstown/p1445224799003958
+        if $::operatingsystemmajrelease == '6' and $name =~ /dev/ {
+          $_package_version = regsubst("${_version}.${_revision}-1", 'dev\.', '\.dev')
+        } else {
+          $_package_version = "${_version}.${_revision}-1"
+        }
       } else {
         $_package_version = "${_version}-${_revision}"
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
Even though the build pipeline uses the same workflow and same instructions and same scripts as RHEL 7 and friends, a small shift of a period (`.`) happens in the version name.

This PR corrects this behavior if it is observed on RHEL 6