### PR TITLE
Re-enable NG_INIT until upstream merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.10.2 (Oct 19. 2015)
+## 0.10.3 (Oct 19. 2015)
 * Fix for RHEL 6 client package installation
+* Re-enable `ng_init` env flag to compat with `st2ctl`
 
 ## 0.10.1 (Oct 16. 2015)
 * Init scripts default install now

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,4 +84,5 @@ class st2(
   $db_host                  = 'localhost',
   $db_port                  = '27017',
   $db_name                  = 'st2'
+  $ng_init                  = true,
 ) inherits st2::params {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,6 @@ class st2(
   $ssh_key_location         = '/home/stanley/.ssh/st2_stanley_key',
   $db_host                  = 'localhost',
   $db_port                  = '27017',
-  $db_name                  = 'st2'
+  $db_name                  = 'st2',
   $ng_init                  = true,
 ) inherits st2::params {}

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -59,6 +59,7 @@ class st2::profile::server (
   $manage_st2auth_service = true,
   $manage_st2web_service  = true,
   $ssh_key_location       = $::st2::ssh_key_location,
+  $ng_init                = $::st2::ng_init,
 ) inherits st2 {
   include '::st2::notices'
   include '::st2::params'
@@ -100,6 +101,15 @@ class st2::profile::server (
   $_logger_config = $syslog ? {
     true    => 'syslog',
     default => 'logging',
+  }
+
+  # This must remain here until upstream packages fully use
+  # init scripts. Otherwise, it's Puppet-specific right now
+  if $ng_init {
+    file_line { 'st2 ng_init enable':
+      path => '/etc/environment',
+      line => 'NG_INIT=true',
+    }
   }
 
   file { $_conf_dir:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
While testing, `st2ctl` needs this flag to ensure that we're using actual services, not stand-alone apps.

Needed until upstream packages fully merge.