### PR TITLE
sysv init script fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.10.3 (Oct 19. 2015)
+## 0.10.4 (Oct 19. 2015)
 * Fix for RHEL 6 client package installation
 * Re-enable `ng_init` env flag to compat with `st2ctl`
+* Fix issue with actionrunners outputting to STDOUT/STDERR
+* All SysV init scripts ensure sourcing from /etc/environment
 
 ## 0.10.1 (Oct 16. 2015)
 * Init scripts default install now

--- a/files/etc/init.d/st2actionrunner
+++ b/files/etc/init.d/st2actionrunner
@@ -23,6 +23,7 @@ args="--config-file /etc/st2/st2.conf"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 if [ -z "$WORKERS" ]; then
   WORKERS=2
@@ -42,7 +43,7 @@ start() {
   while [ $i -le $WORKERS ]; do
     pidfile="/var/run/$name.$i.pid"
     i=`expr $i + 1`
-    $program $args &
+    $program $args > /dev/null 2>&1 &
     echo $! > $pidfile
     emit "$name started"
   done

--- a/files/etc/init.d/st2api
+++ b/files/etc/init.d/st2api
@@ -24,6 +24,7 @@ pidfile="/var/run/$name.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 trace() {
   logger -t "/etc/init.d/st2api" "$@"

--- a/files/etc/init.d/st2auth
+++ b/files/etc/init.d/st2auth
@@ -24,6 +24,7 @@ pidfile="/var/run/$name.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 trace() {
   logger -t "/etc/init.d/st2auth" "$@"

--- a/files/etc/init.d/st2notifier
+++ b/files/etc/init.d/st2notifier
@@ -24,6 +24,7 @@ pidfile="/var/run/$name.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 trace() {
   logger -t "/etc/init.d/st2notifier" "$@"

--- a/files/etc/init.d/st2rulesengine
+++ b/files/etc/init.d/st2rulesengine
@@ -24,6 +24,7 @@ pidfile="/var/run/$name.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 trace() {
   logger -t "/etc/init.d/st2rulesengine" "$@"

--- a/files/etc/init.d/st2sensorcontainer
+++ b/files/etc/init.d/st2sensorcontainer
@@ -24,6 +24,7 @@ pidfile="/var/run/$name.pid"
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 trace() {
   logger -t "/etc/init.d/st2sensorcontainer" "$@"

--- a/files/etc/init.d/st2web
+++ b/files/etc/init.d/st2web
@@ -20,6 +20,7 @@ export PATH
 name="st2web"
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+[ -r /etc/environment ] && . /etc/environment
 
 WEBUI_PORT=${WEBUI_PORT:-8080}
 program="/usr/bin/python"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR ensures that sysv actionrunner scripts do not output to STDOUT/STDERR

Also ensures that `/etc/environment` is sourced.