### PR TITLE
enable backend kwargs for auth manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.5 (Oct 21, 2015)
+* Adding backend kwargs attribute to st2::helper::auth_manager
+
 ## 0.10.4 (Oct 19. 2015)
 * Fix for RHEL 6 client package installation
 * Re-enable `ng_init` env flag to compat with `st2ctl`

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -3,10 +3,11 @@
 #  This defined type is used to configure various kinds of auth plugins for st2
 #
 class st2::helper::auth_manager (
-  $auth_mode    = $::st2::params::auth_mode,
-  $auth_backend = $::st2::params::auth_backend,
-  $debug        = false,
-  $syslog       = false,
+  $auth_mode      = $::st2::params::auth_mode,
+  $auth_backend   = $::st2::params::auth_backend,
+  $debug          = false,
+  $syslog         = false,
+  $backend_kwargs = undef,
 ) inherits st2::params {
 
   $_debug = $debug ? {
@@ -132,6 +133,12 @@ class st2::helper::auth_manager (
 
         # Use inline_template to use native JSON function
         $_auth_backend_kwargs = inline_template('<%= require json; @_kwargs.to_json %>')
+      }
+      default: {
+        if $backend_kwargs {
+          validate_hash($backend_kwargs)
+          $_auth_backend_kwargs = inline_template('<%= require json; @_backend_kwargs.to_json %>')
+        }
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the `Class['::st2::helper::auth_manager']` to accept a `backend_kwargs` argument as a hash to be used for configuration of an authentication plugin.