### PR TITLE
Fix import error for JSON rendering in auth_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.5 (Oct 21, 2015)
+## 0.10.6 (Oct 21, 2015)
 * Adding backend kwargs attribute to st2::helper::auth_manager
 
 ## 0.10.4 (Oct 19. 2015)

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -132,12 +132,12 @@ class st2::helper::auth_manager (
         }
 
         # Use inline_template to use native JSON function
-        $_auth_backend_kwargs = inline_template('<%= require json; @_kwargs.to_json %>')
+        $_auth_backend_kwargs = inline_template('<%= require "json"; @_kwargs.to_json %>')
       }
       default: {
         if $backend_kwargs {
           validate_hash($backend_kwargs)
-          $_auth_backend_kwargs = inline_template('<%= require json; @_backend_kwargs.to_json %>')
+          $_auth_backend_kwargs = inline_template('<%= require "json"; @_backend_kwargs.to_json %>')
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR fixes an import error seen when attempting to use the `backend_kwargs` attribute by properly importing libraries the ruby way.