### PR TITLE
remove GID for st2robots user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.10.6 (Oct 21, 2015)
+## 0.10.7 (Oct 21, 2015)
 * Adding backend kwargs attribute to st2::helper::auth_manager
+* Disable static UID for auto-generated users
 
 ## 0.10.4 (Oct 19. 2015)
 * Fix for RHEL 6 client package installation

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -137,7 +137,7 @@ class st2::helper::auth_manager (
       default: {
         if $backend_kwargs {
           validate_hash($backend_kwargs)
-          $_auth_backend_kwargs = inline_template('<%= require "json"; @_backend_kwargs.to_json %>')
+          $_auth_backend_kwargs = inline_template('<%= require "json"; @backend_kwargs.to_json %>')
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,6 @@
 
 class st2::params(
   $robots_group_name = 'st2robots',
-  $robots_group_gid  = 800,
 ) {
   $subsystems = [
     'actionrunner', 'api', 'sensorcontainer',

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -9,11 +9,9 @@
 #  [*ssh_public_key*]    - SSH Public Key without leading key-type and end email
 #  [*ssh_key_type*]      - Type of SSH Key (ssh-dsa/ssh-rsa)
 #  [*ssh_private_key*]   - Private key
-#  [*uid*]               - UID of admin user (default: 800)
 #
 # === Variables
 #  [*_robots_group_name*] - Local variable to grab the global robot group name
-#  [*_robots_group_gid*]  - Local variable to grab the global robot group GID
 #
 # === Examples
 #
@@ -30,16 +28,13 @@ define st2::user(
   $ssh_key_type      = undef,
   $ssh_public_key    = undef,
   $ssh_private_key   = undef,
-  $uid               = undef,
 ) {
   include ::st2::params
 
   $_robots_group_name = $st2::params::robots_group_name
-  $_robots_group_gid  = $st2::params::robots_group_gid
 
   ensure_resource('group', $_robots_group_name, {
     'ensure' => present,
-    'gid'    => $_robots_group_gid,
   })
 
   if $create_sudo_entry {
@@ -52,7 +47,6 @@ define st2::user(
   ensure_resource('user', $name, {
     'ensure'     => present,
     'shell'      => '/bin/bash',
-    'uid'        => $uid,
     'gid'        => 'st2robots',
     'managehome' => true,
   })

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR removes the static robot user for the `st2robots` group. Not a super great assumption to set UID... this can be managed by the user as needed.