### PR TITLE
Api url setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.8 (Oct 21, 2015)
+* Adding api_url parameter to server profile
+
 ## 0.10.7 (Oct 21, 2015)
 * Adding backend kwargs attribute to st2::helper::auth_manager
 * Disable static UID for auto-generated users

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -245,7 +245,7 @@ class st2::profile::server (
     setting => 'api_url',
     value   => $api_url,
     tag     => 'st2::config',
-  }  
+  }
   ini_setting { 'auth_listen_port':
     ensure  => present,
     path    => '/etc/st2/st2.conf',

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -12,6 +12,7 @@
 #  [*st2api_listen_port*]     - Listen port for st2api process
 #  [*st2auth_listen_ip*]      - Listen IP for st2auth process
 #  [*st2auth_listen_port*]    - Listen port for st2auth process
+#  [*api_url*]                - External API url
 #  [*manage_st2api_service*]  - Toggle whether this module creates an init script for st2api.
 #                               If you disable this, it is your responsibility to create a service
 #                               named `st2api` for `st2ctl` to continue to work.
@@ -55,6 +56,7 @@ class st2::profile::server (
   $st2api_listen_port     = '9101',
   $st2auth_listen_ip      = '0.0.0.0',
   $st2auth_listen_port    = '9100',
+  $api_url                = $::st2::api_url,
   $manage_st2api_service  = true,
   $manage_st2auth_service = true,
   $manage_st2web_service  = true,
@@ -236,6 +238,14 @@ class st2::profile::server (
     value   => $_enable_auth,
     tag     => 'st2::config',
   }
+  ini_setting { 'auth_api_url':
+    ensure  => present,
+    path    => '/etc/st2/st2.conf',
+    section => 'auth',
+    setting => 'api_url',
+    value   => $api_url,
+    tag     => 'st2::config',
+  }  
   ini_setting { 'auth_listen_port':
     ensure  => present,
     path    => '/etc/st2/st2.conf',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
An external API url setting is needed to configure api_url in the auth section of st2.conf