### PR TITLE
stop managing api_url in st2::Profile::server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.1111111111111111111111 (Oct 22, 2015)
+* Limit setting of `api_url` to st2::helper::auth_manager
+
 ## 0.10.8 (Oct 21, 2015)
 * Adding api_url parameter to server profile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.1111111111111111111111 (Oct 22, 2015)
+## 0.10.11 (Oct 22, 2015)
 * Limit setting of `api_url` to st2::helper::auth_manager
 
 ## 0.10.8 (Oct 21, 2015)

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -3,6 +3,7 @@
 #  This defined type is used to configure various kinds of auth plugins for st2
 #
 class st2::helper::auth_manager (
+  $api_url        = $::st2::api_url,
   $auth_mode      = $::st2::params::auth_mode,
   $auth_backend   = $::st2::params::auth_backend,
   $debug          = false,
@@ -14,7 +15,6 @@ class st2::helper::auth_manager (
     true    => 'True',
     default => 'False',
   }
-  $_api_url = $::st2::api_url
   $_st2_conf_file = $::st2::conf_file
 
   $_logger_config = $syslog ? {
@@ -52,7 +52,7 @@ class st2::helper::auth_manager (
     path    => "${_st2_conf_file}",
     section => 'auth',
     setting => 'api_url',
-    value   => $_api_url,
+    value   => $api_url,
     tag     => 'st2::config',
   }
   ini_setting { 'auth_mode':

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -12,7 +12,6 @@
 #  [*st2api_listen_port*]     - Listen port for st2api process
 #  [*st2auth_listen_ip*]      - Listen IP for st2auth process
 #  [*st2auth_listen_port*]    - Listen port for st2auth process
-#  [*api_url*]                - External API url
 #  [*manage_st2api_service*]  - Toggle whether this module creates an init script for st2api.
 #                               If you disable this, it is your responsibility to create a service
 #                               named `st2api` for `st2ctl` to continue to work.
@@ -56,7 +55,6 @@ class st2::profile::server (
   $st2api_listen_port     = '9101',
   $st2auth_listen_ip      = '0.0.0.0',
   $st2auth_listen_port    = '9100',
-  $api_url                = $::st2::api_url,
   $manage_st2api_service  = true,
   $manage_st2auth_service = true,
   $manage_st2web_service  = true,
@@ -238,16 +236,6 @@ class st2::profile::server (
     value   => $_enable_auth,
     tag     => 'st2::config',
   }
-  ### This is really awful and I hate myself for it.  Please revisit.
-  ini_setting { 'auth_ext_api_url':
-    ensure  => present,
-    path    => '/etc/st2/st2.conf',
-    section => 'auth',
-    setting => 'api_url',
-    value   => $api_url,
-    tag     => 'st2::config',
-  }
-  Ini_setting<| title == 'auth_api_url' |> -> Ini_setting<| title == 'auth_ext_api_url' |>
 
   ini_setting { 'auth_listen_port':
     ensure  => present,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the puppet module to limit the management of the `api_url` to only the auth_manager helper.