### PR TITLE
adding default st2pack group to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.12 (Oct 22, 2015)
+* Add st2packs to default deploy and ensure Stanley exists
+
 ## 0.10.11 (Oct 22, 2015)
 * Limit setting of `api_url` to st2::helper::auth_manager
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@
 
 class st2::params(
   $robots_group_name = 'st2robots',
+  $packs_group_name  = 'st2packs',
 ) {
   $subsystems = [
     'actionrunner', 'api', 'sensorcontainer',

--- a/manifests/stanley.pp
+++ b/manifests/stanley.pp
@@ -52,9 +52,9 @@ class st2::stanley (
     client            => $client,
     server            => $server,
     create_sudo_entry => true,
+    groups            => 'st2packs',
     ssh_public_key    => $_ssh_public_key,
     ssh_key_type      => $_ssh_key_type,
     ssh_private_key   => $_ssh_private_key,
   }
-
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -32,8 +32,13 @@ define st2::user(
   include ::st2::params
 
   $_robots_group_name = $st2::params::robots_group_name
+  $_packs_group_name = $st2::params::packs_group_name
 
   ensure_resource('group', $_robots_group_name, {
+    'ensure' => present,
+  })
+
+  ensure_resource('group', $_packs_group_name, {
     'ensure' => present,
   })
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR ensures that the `st2pack` exists (created by packages), and that the default system user is included in this group.