### PR TITLE
Ensure pack directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.14 (Oct 26, 2015)
+* Ensure /opt/stackstorm/packs directory is SGID for pack group
+
 ## 0.10.13 (Oct 22, 2015)
 * Add st2packs to default deploy and ensure Stanley exists
 * Limit setting of `api_url` to st2::helper::auth_manager

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -28,6 +28,7 @@ define st2::pack (
   $_cli_username = $::st2::cli_username
   $_cli_password = $::st2::cli_password
   $_auth = $::st2::auth
+  $_st2_packs_group = $::st2::params::packs_group_name
 
   $_repo_url = $repo_url ? {
     undef   => '',
@@ -42,14 +43,23 @@ define st2::pack (
     default => "subtree=${subtree}",
   }
 
+  ensure_resource('file', '/opt/stackstorm/packs', {
+    'ensure'  => 'directory',
+    'owner'   => 'root',
+    'group'   => $_st2_packs_group,
+    'mode'    => '4775',
+    'recurse' => true,
+  })
+
   exec { "install-st2-pack-${pack}":
-    command     => "st2 run packs.install packs=${pack} ${_repo_url} ${_register} ${_subtree}",
-    creates     => "/opt/stackstorm/packs/${pack}",
-    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
-    tries       => '5',
-    try_sleep   => '10',
+    command   => "st2 run packs.install packs=${pack} ${_repo_url} ${_register} ${_subtree}",
+    creates   => "/opt/stackstorm/packs/${pack}",
+    path      => '/usr/sbin:/usr/bin:/sbin:/bin',
+    tries     => '5',
+    try_sleep => '3',
   }
 
+  Package<| tag == 'st2::package::install' |> -> File['/opt/stackstorm/packs']
   Service<| tag == 'st2::profile::service' |> -> Exec["install-st2-pack-${name}"]
 
   if $config {
@@ -58,7 +68,10 @@ define st2::pack (
       ensure  => file,
       mode    => '0440',
       content => template('st2/config.yaml.erb'),
-      require => Exec["install-st2-pack-${pack}"],
+      require => [
+        Exec["install-st2-pack-${pack}"],
+        File['/opt/stackstorm/packs'],
+      ],
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR ensures that the puppet module correctly sets permissions on the Pack directory to allow services (`st2api`) to read these files when run under a WSGI daemon.