### PR TITLE
Debian Jessie Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -190,4 +190,10 @@ class st2::params(
       $init_type = undef
     }
   }
+
+  ## Python Packages Directory Detection
+  $python_pack = $::osfamily ? {
+    'Debian' => '/usr/lib/python2.7/dist-packages',
+    'RedHat' => '/usr/lib/python2.7/site-packages',
+  }
 }

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -35,6 +35,7 @@
 #  [*_conf_dir*]        - Local scoped variable config directory for st2.
 #                         Sources from st2::params
 #  [*_python_pack*]     - Local scoped variable directory where system python lives
+#                         Sources from st2::params
 #
 # === Examples
 #
@@ -85,11 +86,8 @@ class st2::profile::server (
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
   $_init_provider = $::st2::params::init_type
+  $_python_pack = $::st2::params::python_pack
 
-  $_python_pack = $::osfamily ? {
-    'Debian' => '/usr/lib/python2.7/dist-packages',
-    'RedHat' => '/usr/lib/python2.7/site-packages',
-  }
   $_register_command = $_version ? {
     /^0.8/  => "${_python_pack}/st2common/bin/registercontent.py",
     default => "${_python_pack}/st2common/bin/st2-register-content",

--- a/templates/etc/systemd/system/st2actionrunner.service.erb
+++ b/templates/etc/systemd/system/st2actionrunner.service.erb
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=oneshot
 EnvironmentFile=-/etc/sysconfig/st2actionrunner
-ExecStart=/bin/bash /usr/lib/python2.7/site-packages/st2actions/bin/runners.sh start
-ExecStop=/bin/bash /usr/lib/python2.7/site-packages/st2actions/bin/runners.sh stop
+ExecStart=/bin/bash <%= @runners_script %> start
+ExecStop=/bin/bash <%= @runners_script %> stop
 RemainAfterExit=true
 
 [Install]


### PR DESCRIPTION
- [x] st2actionrunner.service needs to run `/bin/bash /usr/bin/runners.sh [start|stop]` on Jessie
- [x] upstream change in `runners.sh` to check for `/bin/systemctl` instead of `/usr/bin/systemctl`. StackStorm/st2#2140
- [x] st2web.service unit needs to be https://github.com/StackStorm/puppet-st2/blob/master/files/systemd/system/st2web.service and not follow the same autogenerated pattern as the rest of the stackstorm services
- [x] stankevich/puppet-python@725e8decb808a65a92356eecd4681879fb6bfcba needs to release another version