### PR TITLE
Update ghoneycutt-facter to >= 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     {"name":"jfryman-tiller","version_requirement":">= 0.1.0"},
     {"name":"garethr-erlang","version_requirement":">= 0.3.0"},
     {"name":"stahnma-epel","version_requirement":">= 1.1.0"},
-    {"name":"ghoneycutt-facter","version_requirement":">= 2.1.0"}
+    {"name":"ghoneycutt-facter","version_requirement":">= 3.0.0"}
   ]
 }
 


### PR DESCRIPTION
This is needed due to a fix in
ghoneycutt/puppet-module-facter#fe37bc00d2afb99624d8b18d7b27c7a59cbd6b1e
