### PR TITLE
Disable upstart logging for st2 services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## TBD
+* Disable upstart logging for st2 services.
+
 ## 0.10.17 (Nov 2, 2015)
 * Parameterized download server to CI
 

--- a/files/etc/init/st2api.conf
+++ b/files/etc/init/st2api.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2api
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2auth.conf
+++ b/files/etc/init/st2auth.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2auth
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2notifier.conf
+++ b/files/etc/init/st2notifier.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2notifier
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2resultstracker.conf
+++ b/files/etc/init/st2resultstracker.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2resultstracker
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2rulesengine.conf
+++ b/files/etc/init/st2rulesengine.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2rulesengine
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2sensorcontainer.conf
+++ b/files/etc/init/st2sensorcontainer.conf
@@ -10,6 +10,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2sensorcontainer
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"

--- a/files/etc/init/st2web.conf
+++ b/files/etc/init/st2web.conf
@@ -22,5 +22,5 @@ script
   WEBUI_LOG_FILE=${WEBUI_LOG_FILE:-/var/log/st2/st2web.log}
 
   cd /opt/stackstorm/static/webui/
-  nohup python -m SimpleHTTPServer $WEBUI_PORT > $WEBUI_LOG_FILE 2>&1
+  nohup python -m SimpleHTTPServer $WEBUI_PORT >> $WEBUI_LOG_FILE 2>&1
 end script

--- a/files/etc/init/st2web.conf
+++ b/files/etc/init/st2web.conf
@@ -10,13 +10,17 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since we redirect output to /var/log/st2
+console none
+
 script
   NAME=st2web
 
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
   WEBUI_PORT=${WEBUI_PORT:-8080}
+  WEBUI_LOG_FILE=${WEBUI_LOG_FILE:-/var/log/st2/st2web.log}
 
   cd /opt/stackstorm/static/webui/
-  nohup python -m SimpleHTTPServer $WEBUI_PORT
+  nohup python -m SimpleHTTPServer $WEBUI_PORT > $WEBUI_LOG_FILE 2>&1
 end script

--- a/templates/etc/init/st2actionrunner-worker.conf.erb
+++ b/templates/etc/init/st2actionrunner-worker.conf.erb
@@ -13,6 +13,9 @@ respawn limit 2 5
 umask 007
 kill timeout 60
 
+# We disable upstart service logs since st2 manages logs by itself
+console none
+
 script
   NAME=st2actionrunner
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"


### PR DESCRIPTION
This fixes #120.

I've tested it on build server and it seems to work fine.

For reference, see http://upstart.ubuntu.com/cookbook/#console (and upstart which runs on Ubuntu 12.04 is 1.12.1-0ubuntu4.2 so `console log` is the default).

P.S. 1 We should also include this fix in v1.1.1.

P.S. 2 That was the root cause of st2build002 and st2ops constantly getting "messed" up (it was disk being full) - it started happening after we upgraded st2 to a newer version which ships with and uses upstart scripts.