### PR TITLE
WIP: Install pip in rhel7 too

### DIFF
--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -16,7 +16,7 @@
 #  include st2::profile::python
 #
 class st2::profile::python {
-  if ($::osfamily == "RedHat") and ($operatingsystemmajrelease == '6') {
+  if ($::osfamily == "RedHat") {
     package {'python27':
       ensure => 'latest'
     }


### PR DESCRIPTION
Turns out a shiny new rhel box doesn't have pip installed by default. So https://github.com/StackStorm/st2workroom/blob/master/modules/profile/manifests/python.pp#L15 is pretty much a noop I think. See logs here. https://gist.github.com/lakshmi-kannan/10749a7b5fc8107100d8#file-gistfile1-txt-L98. The step runs but I am guessing pip doesn't get installed. 

https://gist.github.com/lakshmi-kannan/10749a7b5fc8107100d8#file-gistfile1-txt-L18 is another place where we 'ensure' python-pip is installed on the box. 