### PR TITLE
Add support for bintray debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.1 (Dec 9, 2015)
+* Adding ability to download packages from testing bintray repos
+
 ## 0.11.1 (Dec 9, 2015)
 * Extract a new version of st2web on update
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,8 @@
 #  [*revision*]           - Revision of StackStorm to install
 #  [*autoupdate*]         - Automatically update to latest stable. (default: false)
 #  [*mistral_git_branch*] - Tagged branch of Mistral to download/install
+#  [*repo_url*]           - The URL where the StackStorm project is hosted on GitHub
+#  [*repo_env*]           - Specify the environment of package repo (production, staging)
 #  [*conf_file*]          - The path where st2 config is stored
 #  [*use_ssl*]            - Enable/Disable SSL for all st2 APIs
 #  [*ssl_key*]            - The path to SSL key for all st2 APIs
@@ -51,6 +53,7 @@ class st2(
   $autoupdate               = false,
   $mistral_git_branch       = 'st2-1.1.0',
   $repo_base                = $::st2::params::repo_base,
+  $repo_env                 = $::st2::params::repo_env,
   $conf_dir                 = $::st2::params::conf_dir,
   $conf_file                = "${::st2::params::conf_dir}/st2.conf",
   $use_ssl                  = false,

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -22,7 +22,7 @@ class st2::package::debian {
   }
 
   case $_repo_base {
-    /dl.bintray.com/ => {
+    /dl.bintray.com/: {
       $_repo_suffix = $_repo_env ? {
         'staging' => '_staging',
         default   => undef,
@@ -37,7 +37,7 @@ class st2::package::debian {
       $_key        = '' # TODO: Fill out
       $_key_source = '' # TODO: Fill out
     }
-    default => {
+    default: {
       # download.stackstorm.com
       $_location   = "${_repo_base}/deb/"
       $_release    = "${::lsbdistcodename}_${_suite}"

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -34,8 +34,8 @@ class st2::package::debian {
         "${::lsbdistcodename}${_repo_suffix}",
       ], '/')
       $_release    = $_suite
-      $_key        = '' # TODO: Fill out
-      $_key_source = '' # TODO: Fill out
+      $_key        = 'A850304EED82AE89A136271F1AB74003483DED8B'
+      $_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
     }
     default: {
       # download.stackstorm.com

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -9,23 +9,49 @@
 #  include ::st2::package::debian
 class st2::package::debian {
   $_version = $::st2::version
+  $_repo_base = $::st2::repo_base
+  $_repo_env = $::st2::repo_env
 
   if !defined(Class['::apt']) {
     include ::apt
   }
 
-  if $_version =~ /dev$/ {
-    $_suite = "unstable"
-  } else {
-    $_suite = "stable"
+  $_suite = $_version ? {
+    /dev$/  => 'unstable',
+    default => 'stable',
+  }
+
+  case $_repo_base {
+    /dl.bintray.com/ => {
+      $_repo_suffix = $_repo_env ? {
+        'staging' => '_staging',
+        default   => undef,
+      }
+
+      $_location   = join([
+        $_repo_base,
+        'stackstorm',
+        "${::lsbdistcodename}${_repo_suffix}",
+      ], '/')
+      $_release    = $_suite
+      $_key        = '' # TODO: Fill out
+      $_key_source = '' # TODO: Fill out
+    }
+    default => {
+      # download.stackstorm.com
+      $_location   = "${_repo_base}/deb/"
+      $_release    = "${::lsbdistcodename}_${_suite}"
+      $_key        = '1E26DCC8B9D4E6FCB65CC22E40A96AE06B8C7982'
+      $_key_source = "${_location}/pubkey.gpg"
+    }
   }
 
   apt::source { 'stackstorm':
-    location    => "${::st2::repo_base}/deb/",
-    release     => "${::lsbdistcodename}_${_suite}",
+    location    => $_location,
+    release     => $_release,
     repos       => 'main',
     include_src => false,
-    key         => '1E26DCC8B9D4E6FCB65CC22E40A96AE06B8C7982',
-    key_source  => "${::st2::repo_base}/deb/pubkey.gpg",
+    key         => $_key,
+    key_source  => $_key_source,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@
 #
 # === Variables
 #  [*repo_url*] - The URL where the StackStorm project is hosted on GitHub
+#  [*repo_env*] - Specify the environment of package repo (production, staging)
 #  [*conf_dir*] - The local directory where st2 config is stored
 #  [*subsystems*] - Different executable subsystems within StackStorm
 #  [*component_map*] - Hash table of mappings of Subsystems -> Components
@@ -76,11 +77,12 @@ class st2::params(
   }
 
   $repo_base = 'https://downloads.stackstorm.net'
-  
+  $repo_env = 'production'
+
   # Auth settings
   $auth_mode = standalone
   $auth_backend = pam
-  
+
   # Non-user configurable parameters
   $repo_url = 'https://github.com/StackStorm/st2'
   $conf_dir = '/etc/st2'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This PR updates the module to allow for using/testing out the new BinTray repositories currently being tested.

To use:

## Hiera
```
st2::repo_root: https://dl.bintray.com
st2::repo_env: staging
```

## Class
```
  class { '::st2':
    repo_root => 'https://dl.bintray.com',
    repo_env  => 'staging',
  }
```

## TODO
* [x] add GPG path/keysig for Bintray before merging. /cc @armab 
