### PR TITLE
Move mistral api under gunicorn

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class st2(
   $workers                  = 8,
   $mistral_api_url          = undef,
   $mistral_api_port         = '8989',
-  $mistral_api_service      = true,
+  $mistral_api_service      = false,
   $syslog                   = false,
   $syslog_host              = 'localhost',
   $syslog_protocol          = 'udp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class st2(
   $workers                  = 8,
   $mistral_api_url          = undef,
   $mistral_api_port         = '8989',
+  $mistral_api_service      = true,
   $syslog                   = false,
   $syslog_host              = 'localhost',
   $syslog_protocol          = 'udp',

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -166,6 +166,12 @@ class st2::profile::mistral(
     virtualenv   => "${_mistral_root}/.venv"
   }
 
+  python::pip { 'gunicorn':
+    pkgname => 'gunicorn',
+    ensure => present,
+    virtualenv   => "${_mistral_root}/.venv"
+  }
+
   python::pip { 'python-mistralclient':
     ensure => present,
     url    => "git+https://github.com/StackStorm/python-mistralclient.git@${_git_branch}",

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -14,10 +14,10 @@
 #  [*db_max_pool_size*]    - Max DB Pool size for Mistral Connections
 #  [*db_max_overflow*]     - Max DB overload for Mistral Connections
 #  [*db_pool_recycle*]     - DB Pool recycle time
-#  [*api_url*]             - URI of Mistral backend (e.x.: http://localhost)
-#  [*api_port*]            - Port of Mistral backend. (Default: 8989)
+#  [*api_url*]             - URI of Mistral backend (e.x.: 127.0.0.1)
+#  [*api_port*]            - Port of Mistral backend. Default: 8989
 #  [*manage_service*]      - Manage the Mistral service. Default: true
-#  [*disable_api*]         - Disables the API subsystem. Default: false
+#  [*disable_api*]         - Disables the embedded API subsystem. Default: true (served by gunicorn)
 #  [*disable_executor*]    - Disables the executor subsystem. Default: false
 #  [*disable_engine*]      - Disables the engine subsystem. Default: false
 #
@@ -46,7 +46,7 @@ class st2::profile::mistral(
   $api_url             = $::st2::mistral_api_url,
   $api_port            = $::st2::mistral_api_port,
   $manage_service      = true,
-  $disable_api         = false,
+  $disable_api         = true,
   $disable_executor    = false,
   $disable_engine      = false,
 ) inherits st2 {
@@ -309,7 +309,7 @@ class st2::profile::mistral(
     content => 'mistral_bootstrapped=true',
   }
 
-  ### Set Mistral API Settings. Useful when setting up uWSGI or other server
+  ### Set Mistral API Settings. Used when API runs embedded (disable_api=false).
   if $api_url {
     ini_setting { 'mistral_api_host':
       ensure  => present,

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -359,6 +359,14 @@ class st2::profile::mistral(
           content => template('st2/etc/init/mistral.conf.erb'),
           notify  => Service['mistral'],
         }
+        file { '/etc/init/mistral-api.conf':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0444',
+          content => template('st2/etc/init/mistral-api.conf.erb'),
+          notify  => Service['mistral'],
+        }
       }
       'systemd': {
         file { '/etc/systemd/system/mistral.service':

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -396,7 +396,7 @@ class st2::profile::mistral(
           owner  => 'root',
           group  => 'root',
           mode   => '0444',
-          content => template('st2/etc/systemd/system//mistral-api.service.erb'),
+          content => template('st2/etc/systemd/system/mistral-api.service.erb'),
           notify  => Service['mistral'],
         }
       }
@@ -408,6 +408,20 @@ class st2::profile::mistral(
           mode   => '0755',
           content => template('st2/etc/init.d/mistral.erb'),
           notify  => Service['mistral'],
+        }
+        if $api_service {
+          file { '/etc/init.d/mistral-api':
+            ensure => file,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0755',
+            content => template('st2/etc/init.d/mistral-api.erb'),
+            notify  => Service['mistral'],
+          }
+        } else {
+            file { '/etc/init.d/mistral-api':
+            ensure => absent,
+          }
         }
       }
     }

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -383,6 +383,14 @@ class st2::profile::mistral(
           content => template('st2/etc/systemd/system/mistral.service.erb'),
           notify  => Service['mistral'],
         }
+        file { '/etc/systemd/system/mistral-api.service':
+          ensure => file,
+          owner  => 'root',
+          group  => 'root',
+          mode   => '0444',
+          content => template('st2/etc/systemd/system//mistral-api.service.erb'),
+          notify  => Service['mistral'],
+        }
       }
       'init': {
         file { '/etc/init.d/mistral':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",

--- a/templates/etc/init.d/mistral-api.erb
+++ b/templates/etc/init.d/mistral-api.erb
@@ -1,0 +1,97 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+name="mistral-api"
+dir="/opt/openstack/mistral"
+cmd="/opt/openstack/mistral/.venv/bin/gunicorn -b <%= @api_url %>:<%= @api_port %> -w 2 mistral.api.wsgi"
+user="root"
+
+pid_file="/var/run/$name.pid"
+stdout_log="/var/log/$name.log"
+stderr_log="/var/log/$name.err"
+
+get_pid() {
+    cat "$pid_file"
+}
+
+is_running() {
+    [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+        if [ -z "$user" ]; then
+            su -c "$cmd" >> "$stdout_log" 2>> "$stderr_log" &
+        else
+            su $user -c "$cmd" >> "$stdout_log" 2>> "$stderr_log" &
+        fi
+        echo $! > "$pid_file"
+        if ! is_running; then
+            echo "Unable to start, see $stdout_log and $stderr_log"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+        kill `get_pid`
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; may still be shutting down or shutdown may have failed"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/etc/init/mistral-api.conf.erb
+++ b/templates/etc/init/mistral-api.conf.erb
@@ -1,0 +1,10 @@
+# Moving under puppet. To enable:
+# 1. Install gunicorn to mistral virutal env /opt/stackstorm/mistral/.venv
+# 2. Modify /etc/init/mistral.conf and remove "api" from --server
+# 3. Modify st2ctl to add mistral-api
+# 4. Remove these comments :)
+
+description "Mistral Workflow API Service"
+
+chdir /opt/openstack/mistral
+exec /opt/openstack/mistral/.venv/bin/gunicorn -b 0.0.0.0:8989 -w 2 mistral.api.wsgi

--- a/templates/etc/init/mistral-api.conf.erb
+++ b/templates/etc/init/mistral-api.conf.erb
@@ -1,10 +1,4 @@
-# Moving under puppet. To enable:
-# 1. Install gunicorn to mistral virutal env /opt/stackstorm/mistral/.venv
-# 2. Modify /etc/init/mistral.conf and remove "api" from --server
-# 3. Modify st2ctl to add mistral-api
-# 4. Remove these comments :)
-
-description "Mistral Workflow API Service"
+description "StackStorm's Mistral Workflow API Service"
 
 start on starting mistral
 stop on stopping mistral

--- a/templates/etc/init/mistral-api.conf.erb
+++ b/templates/etc/init/mistral-api.conf.erb
@@ -6,5 +6,10 @@
 
 description "Mistral Workflow API Service"
 
-chdir /opt/openstack/mistral
-exec /opt/openstack/mistral/.venv/bin/gunicorn -b 0.0.0.0:8989 -w 2 mistral.api.wsgi
+start on starting mistral
+stop on stopping mistral
+
+script
+    chdir /opt/openstack/mistral
+    exec /opt/openstack/mistral/.venv/bin/gunicorn -b <%= @api_url %>:<%= @api_port %> -w 2 mistral.api.wsgi
+end script

--- a/templates/etc/init/mistral.conf.erb
+++ b/templates/etc/init/mistral.conf.erb
@@ -1,4 +1,5 @@
-description "OpenStack Workflow Service"
+description "StackStorm's Mistral Workflow Service"
+
 start on runlevel [2345]
 stop on runlevel [016]
 respawn

--- a/templates/etc/systemd/system/mistral-api.service.erb
+++ b/templates/etc/systemd/system/mistral-api.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mistral Workflow API Service
+BindsTo=mistral.service
 
 [Service]
 ExecStart=/opt/openstack/mistral/.venv/bin/gunicorn -b <%= @api_url %>:<%= @api_port %> -w 2 mistral.api.wsgi

--- a/templates/etc/systemd/system/mistral-api.service.erb
+++ b/templates/etc/systemd/system/mistral-api.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Mistral Workflow API Service
+
+[Service]
+ExecStart=/opt/openstack/mistral/.venv/bin/gunicorn -b <%= @api_url %>:<%= @api_port %> -w 2 mistral.api.wsgi
+WorkingDirectory=/opt/openstack/mistral
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/etc/systemd/system/mistral.service.erb
+++ b/templates/etc/systemd/system/mistral.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mistral Workflow Service
+Wants=mistral-api.service
 
 [Service]
 ExecStart=/opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral.log --log-config-append /etc/mistral/wf_trace_logging.conf --server "<%= @subsystems %>"

--- a/templates/etc/systemd/system/mistral.service.erb
+++ b/templates/etc/systemd/system/mistral.service.erb
@@ -1,6 +1,9 @@
 [Unit]
 Description=Mistral Workflow Service
+
+<% if @api_service -%>
 Wants=mistral-api.service
+<% end -%>
 
 [Service]
 ExecStart=/opt/openstack/mistral/.venv/bin/python /opt/openstack/mistral/mistral/cmd/launch.py --config-file /etc/mistral/mistral.conf --log-file /var/log/mistral.log --log-config-append /etc/mistral/wf_trace_logging.conf --server "<%= @subsystems %>"


### PR DESCRIPTION
- [x] make all work on ubuntu (gunicorn, mistral-api init, make mistral-mistral-api services start at once)
- [x] add systemd / rhel7 support
- [x] make st2ctl start/stop both mistral services on rhel7 (done by service dependency)
- [x] add "feature flag"
- [x] support rhel6 system V init.d
- [x] ~~rewrite mistral / mistral api init.d scripts to be like st2api as @DoriftoShoes suggested~~ separate PR.
- [x] increment version (and merge, and push to puppet-forge)