### PR TITLE
Move misaligned resource metaparameter inside conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.2 (Dec 11, 2015)
+* Fixing error where WebUI fails because of missing resource
+
 ## 0.12.1 (Dec 9, 2015)
 * Adding ability to download packages from testing bintray repos
 
@@ -7,7 +10,7 @@
 * Extract a new version of st2web on update
 
 ## 0.11.0 (Dec 4, 2015)
-* Force rewrite of webui/config.js on every provision 
+* Force rewrite of webui/config.js on every provision
 
 ## 0.10.18 (Nov 11, 2015)
 * Disable upstart logging for st2 services.

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -57,7 +57,10 @@ class st2::profile::web(
       command => 'tar -xzvf /tmp/st2web.tar.gz -C /opt/stackstorm/static/webui --strip-components=1 --owner root --group root --no-same-owner',
       path    => '/usr/bin:/usr/sbin:/bin:/sbin',
       require => File['/opt/stackstorm/static/webui'],
-      before  => File['/etc/facter/facts.d/st2web_bootstrapped.txt'],
+      before  => [
+        File['/etc/facter/facts.d/st2web_bootstrapped.txt'],
+        File['/opt/stackstorm/static/webui/config.js'],
+      ],
     }
   }
 
@@ -69,7 +72,6 @@ class st2::profile::web(
     group   => 'root',
     mode    => '0444',
     content => template('st2/opt/st2web/config.js.erb'),
-    require => Exec['extract webui'],
   }
 
   file { '/etc/facter/facts.d/st2web_bootstrapped.txt':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
In this PR, `st2web` can run into a situation where `autoupdate` is set to `false` (Default), and the bootstrap of the class is done.

This adjusts the metaparameter ordering to keep the DAG intact, but move the resource dependency inside of the conditional to avoid compilation errors.