### PR TITLE
Remove duplicate http protocol from repo urls

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -21,12 +21,6 @@ class st2::package::debian(
     /dev$/  => 'unstable',
     default => 'stable',
   }
-
-  if $repo_base =~ /https/ {
-    $repo_protocol = 'https://'
-  } else {
-    $repo_protocol = 'http://'
-  }
   
   case $repo_base {
     /^https:\/\/dl.bintray.com/: {
@@ -45,7 +39,7 @@ class st2::package::debian(
       $_key_source = 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
     }
     default: {
-      $_location   = "${repo_protocol}${repo_base}/deb/"
+      $_location   = "${repo_base}/deb/"
       $_release    = "${::lsbdistcodename}_${_suite}"
       $_key        = '1E26DCC8B9D4E6FCB65CC22E40A96AE06B8C7982'
       $_key_source = "${_location}/pubkey.gpg"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
I added a secondary http to the beginning of the protocol for some unexplainable reason last night.  This fixes that.