### PR TITLE
Revert "RFR: Set virtualenv_opts to just --system-site-packages for old packages"

### DIFF
--- a/files/etc/st2/st2.conf.erb
+++ b/files/etc/st2/st2.conf.erb
@@ -24,7 +24,6 @@
 <%- db_username = env_st2_db_username || nil -%>
 <%- db_password = env_st2_db_password || nil -%>
 <%- mask_secrets = env_mask_secrets || 'True' -%>
-<%- pack_virtualenv_opts = env_pack_virtualenv_opts || '--system-site-packages' -%>
 
 [api]
 # Host and port to bind the API server.
@@ -44,7 +43,6 @@ logging = <%= conf_root %>/st2reactor/conf/console.conf
 
 [actionrunner]
 logging = <%= conf_root %>/st2actions/conf/console.conf
-virtualenv_opts = <%= pack_virtualenv_opts %>
 
 [auth]
 host = 0.0.0.0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.13.3",
+  "version": "0.13.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
Reverts StackStorm/puppet-st2#148

The workroom tests are still failing. The config never made it to the boxes. I have no idea what's wrong. At this point, I'll revert this change and also the st2 change https://github.com/StackStorm/st2/pull/2372.

Unless this puppet change lands correctly, we cannot do anything. 