### PR TITLE
Update init scripts to exit if gargabe collector service is not available

### DIFF
--- a/files/etc/init.d/st2garbagecollector
+++ b/files/etc/init.d/st2garbagecollector
@@ -36,6 +36,11 @@ emit() {
 }
 
 start() {
+  if [ ! -f $program ]; then
+      # Service not available or installed
+      return 1
+  fi
+
   $program $args > /dev/null 2>&1 &
   echo $! > $pidfile
   emit "$name started"

--- a/files/etc/init/st2garbagecollector.conf
+++ b/files/etc/init/st2garbagecollector.conf
@@ -15,10 +15,16 @@ console none
 
 script
   NAME=st2garbagecollector
+  PROGRAM="/usr/bin/${NAME}"
   DEFAULT_ARGS="--config-file /etc/st2/st2.conf"
 
   # Read configuration variable file if it is present
   [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-  /usr/bin/$NAME ${DEFAULT_ARGS}
+  if [ ! -f ${PROGRAM} ]; then
+    # Service not available
+    exit 1
+  fi
+
+  ${PROGRAM} ${DEFAULT_ARGS}
 end script

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache 2.0",


### PR DESCRIPTION
This is needed so this change won't break existing 1.2.0 installations.