### PR TITLE
Fix depreciation warnings with puppetlabs-apt resources

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -47,11 +47,15 @@ class st2::package::debian(
   }
 
   apt::source { 'stackstorm':
-    location    => $_location,
-    release     => $_release,
-    repos       => 'main',
-    include_src => false,
-    key         => $_key,
-    key_source  => $_key_source,
+    location => $_location,
+    release  => $_release,
+    repos    => 'main',
+    include  => {
+        'src' => false
+    },
+    key      => {
+        'id'     => $_key,
+        'source' => $_key_source
+    },
   }
 }


### PR DESCRIPTION
fixes the following depreciation warnings:

```
Warning: Scope(Apt::Source[stackstorm]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
Warning: Scope(Apt::Source[stackstorm]): $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => https://downloads.stackstorm.net/deb//pubkey.gpg } instead.
Warning: Scope(Apt::Key[Add key: 1E26DCC8B9D4E6FCB65CC22E40A96AE06B8C7982 from Apt::Source stackstorm]): $key_source is deprecated and will be removed in the next major release. Please use $source instead.
```