### PR TITLE
Require git

### DIFF
--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -51,6 +51,8 @@ class st2::profile::mistral(
   $disable_engine      = false,
 ) inherits st2 {
   require '::st2::dependencies'
+  
+  ensure_packages('git')
 
   $_st2_version = $autoupdate ? {
     undef   => st2_latest_stable(),
@@ -119,7 +121,7 @@ class st2::profile::mistral(
     source   => 'https://github.com/StackStorm/mistral.git',
     revision => $_git_branch,
     provider => 'git',
-    require  => File['/opt/openstack'],
+    require  => [File['/opt/openstack'], Package['git']],
     before   => $_mistral_root_before,
   }
   vcsrepo { '/etc/mistral/actions/st2mistral':
@@ -127,7 +129,7 @@ class st2::profile::mistral(
     source => 'https://github.com/StackStorm/st2mistral.git',
     revision => $_git_branch,
     provider => 'git',
-    require  => File['/etc/mistral/actions'],
+    require  => [File['/etc/mistral/actions'], Package['git']],
     before   => $_st2mistral_before,
   }
 

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -121,29 +121,35 @@ class st2::profile::mistral(
     source   => 'https://github.com/StackStorm/mistral.git',
     revision => $_git_branch,
     provider => 'git',
-    require  => [File['/opt/openstack'], Package['git']],
+    require  => [
+        File['/opt/openstack'],
+        Package['git']
+    ],
     before   => $_mistral_root_before,
   }
   vcsrepo { '/etc/mistral/actions/st2mistral':
-    ensure => $_update_vcsroot,
-    source => 'https://github.com/StackStorm/st2mistral.git',
+    ensure   => $_update_vcsroot,
+    source   => 'https://github.com/StackStorm/st2mistral.git',
     revision => $_git_branch,
     provider => 'git',
-    require  => [File['/etc/mistral/actions'], Package['git']],
+    require  => [
+        File['/etc/mistral/actions'],
+        Package['git']
+    ],
     before   => $_st2mistral_before,
   }
 
   file { '/etc/mistral/wf_trace_logging.conf':
-    ensure  => file,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0444',
-    source  => 'puppet:///modules/st2/etc/mistral/wf_trace_logging.conf',
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0444',
+    source => 'puppet:///modules/st2/etc/mistral/wf_trace_logging.conf',
   }
 
   ### END Mistral Downloads ###
 
-  if ($::osfamily == "RedHat") and ($operatingsystemmajrelease == '6') {
+  if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '6') {
     $python_version = '2.7'
   } else {
     $python_version = 'system'
@@ -151,16 +157,16 @@ class st2::profile::mistral(
 
   ### Bootstrap Python ###
   python::virtualenv { $_mistral_root:
-    ensure       => present,
-    version      => $python_version,
-    systempkgs   => false,
-    venv_dir     => "${_mistral_root}/.venv",
-    cwd          => $_mistral_root,
-    notify       => [
+    ensure     => present,
+    version    => $python_version,
+    systempkgs => false,
+    venv_dir   => "${_mistral_root}/.venv",
+    cwd        => $_mistral_root,
+    notify     => [
       Exec['setup mistral', 'setup st2mistral plugin'],
       Exec['python_requirementsmistral'],
     ],
-    before       => File['/etc/mistral/database_setup.lock'],
+    before     => File['/etc/mistral/database_setup.lock'],
   }
 
   # Not using virtualenv requirements attribute because oslo has bad wheel, and fails
@@ -171,21 +177,21 @@ class st2::profile::mistral(
 
   if $api_service {
     python::pip { 'gunicorn':
-      pkgname => 'gunicorn',
-      ensure => present,
-      virtualenv   => "${_mistral_root}/.venv"
+      ensure     => present,
+      pkgname    => 'gunicorn',
+      virtualenv => "${_mistral_root}/.venv"
     }
   }
 
   python::pip { 'python-mistralclient':
-    ensure => present,
-    url    => "git+https://github.com/StackStorm/python-mistralclient.git@${_git_branch}",
-    before   => [
+    ensure     => present,
+    url        => "git+https://github.com/StackStorm/python-mistralclient.git@${_git_branch}",
+    before     => [
       Exec['setup mistral'],
       Exec['setup st2mistral plugin'],
       Exec['setup mistral database'],
     ],
-    virtualenv   => "${_mistral_root}/.venv"
+    virtualenv => "${_mistral_root}/.venv"
   }
   ### END Bootstrap Python ###
 
@@ -260,7 +266,7 @@ class st2::profile::mistral(
     path    => '/etc/mistral/mistral.conf',
     section => 'pecan',
     setting => 'auth_enable',
-    value   => 'false',
+    value   => false,
   }
 
 
@@ -280,12 +286,12 @@ class st2::profile::mistral(
 
   postgresql::server::db { 'mistral':
     user     => 'mistral',
-    password => postgresql_password('mistral', "${db_mistral_password}"),
+    password => postgresql_password('mistral', $db_mistral_password),
     before   => Exec['setup mistral database'],
   }
 
   file { '/etc/mistral/database_setup.lock':
-    ensure => file,
+    ensure  => file,
     content => 'This file is the lock file that prevents Puppet from attempting to setup the database again. Delete this file if it needs to be re-run',
     notify  => Exec['setup mistral database'],
   }
@@ -323,10 +329,10 @@ class st2::profile::mistral(
 
   # Once everything is done, let the system know so we can avoid some future processing
   file { '/etc/facter/facts.d/mistral_bootstrapped.txt':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0444',
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
     content => 'mistral_bootstrapped=true',
   }
 
@@ -379,19 +385,19 @@ class st2::profile::mistral(
     case $_init_type {
       'upstart': {
         file { '/etc/init/mistral.conf':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0444',
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0444',
           content => template('st2/etc/init/mistral.conf.erb'),
           notify  => Service['mistral'],
         }
         if $api_service {
           file { '/etc/init/mistral-api.conf':
-            ensure => file,
-            owner  => 'root',
-            group  => 'root',
-            mode   => '0444',
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0444',
             content => template('st2/etc/init/mistral-api.conf.erb'),
             notify  => Service['mistral'],
           }
@@ -403,37 +409,37 @@ class st2::profile::mistral(
       }
       'systemd': {
         file { '/etc/systemd/system/mistral.service':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0444',
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0444',
           content => template('st2/etc/systemd/system/mistral.service.erb'),
           notify  => Service['mistral'],
         }
         file { '/etc/systemd/system/mistral-api.service':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0444',
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0444',
           content => template('st2/etc/systemd/system/mistral-api.service.erb'),
           notify  => Service['mistral'],
         }
       }
       'init': {
         file { '/etc/init.d/mistral':
-          ensure => file,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0755',
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0755',
           content => template('st2/etc/init.d/mistral.erb'),
           notify  => Service['mistral'],
         }
         if $api_service {
           file { '/etc/init.d/mistral-api':
-            ensure => file,
-            owner  => 'root',
-            group  => 'root',
-            mode   => '0755',
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0755',
             content => template('st2/etc/init.d/mistral-api.erb'),
             notify  => Service['mistral'],
           }

--- a/manifests/profile/source.pp
+++ b/manifests/profile/source.pp
@@ -16,6 +16,9 @@ class st2::profile::source(
   $branch = 'master',
 ) {
   include ::st2::profile::python
+
+  ensure_packages('git')
+
   $_repo_root = '/opt/stackstorm/src'
 
   file { '/opt/stackstorm':
@@ -30,7 +33,7 @@ class st2::profile::source(
     source   => 'https://github.com/StackStorm/st2.git',
     revision => $branch,
     provider => 'git',
-    require  => File['/opt/stackstorm'],
+    require  => [File['/opt/stackstorm'], Package['git']],
   }
 
   file { '/etc/st2':

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,6 @@
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0"},
     {"name":"nanliu/staging","version_requirement":">= 1.0.2"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.7.0"},
-    {"name":"maestrodev/git","version_requirement":">= 1.0.6"},
     {"name":"maestrodev/wget","version_requirement":">= 1.5.6"},
     {"name":"saz/sudo","version_requirement":">= 3.0.9"},
     {"name":"stankevich/python","version_requirement":">= 1.7.15"},


### PR DESCRIPTION
The first commit fixes the fact that the module never makes sure that git is installed before it tries to clone git repos.  It appears that the maestrodev-git module was included as a dependency for this, but it was not actually being used to achieve that goal.  That said, because puppetlabs-stdlib is already included, this behavior can be achieved without the extra module dependency using ensure_packages instead.

And in the habit of leaving something better than you found it, I also cleaned up a bunch of puppet-lint issues with the mistral.pp file (one of the two that I modified).  This does not fix all of them, but it does fix the vast majority.