### PR TITLE
Fix depreciation warnings and install latest pip from pip

### DIFF
--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -16,7 +16,7 @@
 #  include st2::profile::python
 #
 class st2::profile::python {
-  if ($::osfamily == "RedHat") and ($operatingsystemmajrelease == '6') {
+  if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '6') {
     package {'python27':
       ensure => 'latest'
     }
@@ -27,9 +27,9 @@ class st2::profile::python {
       ensure => 'latest'
     }
     exec {'install_pip27':
-      path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-      command     => 'easy_install-2.7 pip',
-      require     => Package['python27']
+      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+      command => 'easy_install-2.7 pip',
+      require => Package['python27']
     }
   } else {
     if !defined(Class['::python']) {

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -35,9 +35,10 @@ class st2::profile::python {
     if !defined(Class['::python']) {
       class { '::python':
         version    => 'system',
-        pip        => true,
+        pip        => latest,
         dev        => true,
-        virtualenv => true,
+        virtualenv => present,
+        provider   => 'pip',
       }
     }
   }


### PR DESCRIPTION
Currently on a "clean" container, stackstorm fails to install when using the latest pip that ships with 14.04 (which is the "supported platform" according to stackstorm's docs).  Ensuring that the latest pip is installed from pypi fixes this.

Additionally, This uses latest/present/absent rather than true/false to fix a few depreciation warnings.

There are also some puppet-lint fixes in there as well.

This PR supersedes PR #118 which does not have the fix for the depreciation warnings.