### PR TITLE
Puppet Lint fixes for the rest of the module

### DIFF
--- a/manifests/auth/pam.pp
+++ b/manifests/auth/pam.pp
@@ -18,13 +18,13 @@ class st2::auth::pam(
   $_api_url = "https://${host_ip}:${_st2api_port}"
 
   # TODO: This belongs in a package
-  $distro_path = $osfamily ? {
-    'Debian' => "apt/${lsbdistcodename}",
-    'Ubuntu' => "apt/${lsbdistcodename}",
-    'RedHat' => "yum/el/${operatingsystemmajrelease}"
+  $distro_path = $::osfamily ? {
+    'Debian' => "apt/${::lsbdistcodename}",
+    'Ubuntu' => "apt/${::lsbdistcodename}",
+    'RedHat' => "yum/el/${::operatingsystemmajrelease}"
   }
 
-  wget::fetch { "Download auth pam backend":
+  wget::fetch { 'Download auth pam backend':
     source             => "${::st2::repo_base}/st2community/${distro_path}/auth_backends/st2_auth_backend_pam-${version}-py2.7.egg",
     cache_dir          => '/var/cache/wget',
     nocheckcertificate => true,
@@ -32,10 +32,10 @@ class st2::auth::pam(
   }
 
   exec { 'install pam auth backend':
-    command     => "easy_install-2.7 /tmp/st2_auth_backend_pam-${version}-py2.7.egg",
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
-    require     => Wget::Fetch["Download auth pam backend"],
-    before      => Class['::st2::helper::auth_manager'],
+    command => "easy_install-2.7 /tmp/st2_auth_backend_pam-${version}-py2.7.egg",
+    path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+    require => Wget::Fetch['Download auth pam backend'],
+    before  => Class['::st2::helper::auth_manager'],
   }
 
   class { '::st2::helper::auth_manager':

--- a/manifests/auth/standalone.pp
+++ b/manifests/auth/standalone.pp
@@ -106,7 +106,7 @@ class st2::auth::standalone(
     default => absent,
   }
   st2::auth_user { 'testu':
-    ensure    => $_testuser_ensure,
+    ensure   => $_testuser_ensure,
     password => 'testp',
   }
   st2::auth_user { $_cli_username:

--- a/manifests/helper/auth_manager.pp
+++ b/manifests/helper/auth_manager.pp
@@ -41,7 +41,7 @@ class st2::helper::auth_manager (
   # Common settings for all auth backends
   ini_setting { 'auth_debug':
     ensure  => present,
-    path    => "${_st2_conf_file}",
+    path    => $_st2_conf_file,
     section => 'auth',
     setting => 'debug',
     value   => $_debug,
@@ -49,7 +49,7 @@ class st2::helper::auth_manager (
   }
   ini_setting { 'auth_api_url':
     ensure  => present,
-    path    => "${_st2_conf_file}",
+    path    => $_st2_conf_file,
     section => 'auth',
     setting => 'api_url',
     value   => $api_url,
@@ -57,7 +57,7 @@ class st2::helper::auth_manager (
   }
   ini_setting { 'auth_mode':
     ensure  => present,
-    path    => "${_st2_conf_file}",
+    path    => $_st2_conf_file,
     section => 'auth',
     setting => 'mode',
     value   => $auth_mode,
@@ -67,50 +67,50 @@ class st2::helper::auth_manager (
   if $auth_mode == 'standalone' {
     ini_setting { 'auth_backend':
       ensure  => present,
-      path    => "${_st2_conf_file}",
+      path    => $_st2_conf_file,
       section => 'auth',
       setting => 'backend',
-      value   => "${auth_backend}",
+      value   => $auth_backend,
       tag     => 'st2::config',
     }
     ini_setting { 'auth_logging_file':
       ensure  => present,
-      path    => "${_st2_conf_file}",
+      path    => $_st2_conf_file,
       section => 'auth',
       setting => 'logging',
-      value   => "${_st2_auth_logging_file}",
+      value   => $_st2_auth_logging_file,
       tag     => 'st2::config',
     }
     ini_setting { 'auth_ssl':
       ensure  => present,
-      path    => "${_st2_conf_file}",
+      path    => $_st2_conf_file,
       section => 'auth',
       setting => 'use_ssl',
-      value   => "${_use_ssl_value}",
+      value   => $_use_ssl_value,
       tag     => 'st2::config',
     }
 
 
 # SSL Settings
     if $_use_ssl {
-      if !$ssl_cert or !$ssl_key {
+      if !$::st2::ssl_cert or !$::st2::ssl_key {
         fail('[st2::helper::auth_manager] Missing $ssl_cert or $ssl_key to enable SSL')
       }
 
       ini_setting { 'auth_ssl_cert':
         ensure  => present,
-        path    => "${_st2_conf_file}",
+        path    => $_st2_conf_file,
         section => 'auth',
         setting => 'cert',
-        value   => "${_ssl_cert}",
+        value   => $_ssl_cert,
         tag     => 'st2::config',
       }
       ini_setting { 'auth_ssl_key':
         ensure  => present,
-        path    => "${_st2_conf_file}",
+        path    => $_st2_conf_file,
         section => 'auth',
         setting => 'key',
-        value   => "${_ssl_key}",
+        value   => $_ssl_key,
         tag     => 'st2::config',
       }
     }
@@ -126,9 +126,9 @@ class st2::helper::auth_manager (
         $_db_port = $::st2::db_port
         $_db_name = $::st2::db_name
         $_kwargs  = {
-          'db_host' => "${_db_host}",
-          'db_port' => "${_db_port}",
-          'db_name' => "${_db_name}",
+          'db_host' => $_db_host,
+          'db_port' => $_db_port,
+          'db_name' => $_db_name,
         }
 
         # Use inline_template to use native JSON function
@@ -146,17 +146,17 @@ class st2::helper::auth_manager (
       value => $auth_mode,
     }
     facter::fact { 'st2_auth_backend':
-      value => $_auth_backend,
+      value => $::st2::_auth_backend,
     }
 
     # Only evaluate if kwargs are not undefined.
     if $_auth_backend_kwargs {
       ini_setting { 'auth_backend_kwargs':
         ensure  => present,
-        path    => "${_st2_conf_file}",
+        path    => $_st2_conf_file,
         section => 'auth',
         setting => 'backend_kwargs',
-        value   => "${_auth_backend_kwargs}",
+        value   => $_auth_backend_kwargs,
         tag     => 'st2::config',
       }
     }

--- a/manifests/helper/service_manager.pp
+++ b/manifests/helper/service_manager.pp
@@ -55,6 +55,9 @@ define st2::helper::service_manager (
               content => template("st2/etc/systemd/system/${_subsystem}.service.erb"),
             }
           }
+          default: {
+              crit('Invalid subsystem provided, only st2web and st2actionrunner are valid options')
+          }
         }
 
         exec{ "sysctl enable ${_subsystem}":

--- a/manifests/helper/systemd.pp
+++ b/manifests/helper/systemd.pp
@@ -8,7 +8,7 @@ define st2::helper::systemd (
   ) {
 
   if $process_type == 'multi' {
-    $extra_char = "@"
+    $extra_char = '@'
   } else {
     $extra_char = ''
   }
@@ -28,7 +28,7 @@ define st2::helper::systemd (
       path    => '/bin:/usr/bin:/usr/local/bin',
       command => "systemctl --no-reload enable ${st2_process}",
       require => File["/etc/systemd/system/${st2_process}${extra_char}.service"],
-      notify  => Service["${st2_process}"],
+      notify  => Service[$st2_process],
     }
   }
 }

--- a/manifests/kv.pp
+++ b/manifests/kv.pp
@@ -14,18 +14,18 @@
 #
 #
 define st2::kv (
+  $value,
   $ensure   = present,
   $key      = $name,
-  $value,
 ) {
   include ::st2
 
   exec { "set-st2-key-${key}":
-    command     => "st2 key set ${key} ${value}",
-    unless      => "st2 key get ${key} | grep ${key}",
-    path        => '/usr/sbin:/usr/bin:/sbin:/bin',
-    tries       => '5',
-    try_sleep   => '10',
+    command   => "st2 key set ${key} ${value}",
+    unless    => "st2 key get ${key} | grep ${key}",
+    path      => '/usr/sbin:/usr/bin:/sbin:/bin',
+    tries     => '5',
+    try_sleep => '10',
   }
 
   Service<| tag == 'st2::profile::service' |> -> Exec["set-st2-key-${key}"]

--- a/manifests/notices.pp
+++ b/manifests/notices.pp
@@ -14,10 +14,10 @@
 class st2::notices {
   include '::st2::params'
 
-  $user_missing_client_keys = "ssh_public_key and ssh_key_type need to be supplied for this resource. Help can be found in INSTALL.md if needed"
-  $user_missing_private_key = "ssh_private_key needs to be supplied for this resource. Help can be found in INSTALL.md if needed"
-  $unsupported_os = "Your platform is not yet supported. Please file a bug or submit a bug to $st2::params::repo_url"
-  $auth_test_user_enabled = "The test user for the WebUI is **ENABLED**. Ensure to disable before deploying to production"
-  $web_no_oauth_token = "The Web Interface is currently in limited beta. You will need a key to test this out. Please email us at support@stackstorm.com if you are interested in trying it out and providing feedback"
+  $user_missing_client_keys = 'ssh_public_key and ssh_key_type need to be supplied for this resource. Help can be found in INSTALL.md if needed'
+  $user_missing_private_key = 'ssh_private_key needs to be supplied for this resource. Help can be found in INSTALL.md if needed'
+  $unsupported_os = "Your platform is not yet supported. Please file a bug or submit a bug to ${st2::params::repo_url}"
+  $auth_test_user_enabled = 'The test user for the WebUI is **ENABLED**. Ensure to disable before deploying to production'
+  $web_no_oauth_token = 'The Web Interface is currently in limited beta. You will need a key to test this out. Please email us at support@stackstorm.com if you are interested in trying it out and providing feedback'
 
 }

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -43,7 +43,7 @@ define st2::package::install(
       } else {
         $_package_version = "${_version}-${_revision}"
       }
-      Class["apt::update"] -> Package<| title == $name |>
+      Class['apt::update'] -> Package<| title == $name |>
     }
     'RedHat': {
       include ::st2::package::redhat
@@ -70,7 +70,7 @@ define st2::package::install(
         $_package_version = "${_version}-${_revision}"
       }
     }
-    default: { fail("Class[st2::package]: $st2::notice::unsupported_os") }
+    default: { fail("Class[st2::package]: ${st2::notice::unsupported_os}") }
   }
 
   package { $name:

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,9 +14,9 @@ class st2::package::redhat (
   $_osver = $::operatingsystemmajrelease
 
   if $version =~ /dev$/ {
-    $_suite = "unstable"
+    $_suite = 'unstable'
   } else {
-    $_suite = "stable"
+    $_suite = 'stable'
   }
 
   yumrepo { 'stackstorm':

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -80,8 +80,8 @@ class st2::profile::client (
   st2::dependencies::install { $_client_dependencies: }
 
   st2::package::install { $_client_packages:
-    version  => $_version,
-    revision => $_revision,
+    version   => $_version,
+    revision  => $_revision,
     repo_base => $_repo_base,
   }
 
@@ -98,12 +98,12 @@ class st2::profile::client (
     case $::osfamily {
       'Debian': {
         python::requirements { '/tmp/st2client-requirements.txt':
-          notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
+          notify  => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
           require => Wget::Fetch['Download st2client requirements.txt']
         }
       }
       'RedHat': {
-        if $operatingsystemmajrelease == '6' {
+        if $::operatingsystemmajrelease == '6' {
           exec { 'pip27_install_st2client_reqs':
             path    => '/usr/bin:/usr/sbin:/bin:/sbin',
             command => 'pip2.7 install -U -r /tmp/st2client-requirements.txt',
@@ -112,10 +112,13 @@ class st2::profile::client (
           }
         } else {
           python::requirements { '/tmp/st2client-requirements.txt':
-            notify => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
+            notify  => File['/etc/facter/facts.d/st2client_bootstrapped.txt'],
             require => Wget::Fetch['Download st2client requirements.txt']
           }
         }
+      }
+      default: {
+          crit('Unsupported OS Family, only Debian and RedHat are supported')
       }
     }
   }

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -36,7 +36,7 @@ class st2::profile::fullinstall inherits st2 {
 
   class { '::st2::profile::mistral':
     manage_postgresql => true,
-    before => Anchor['st2::pre_reqs'],
+    before            => Anchor['st2::pre_reqs'],
   }
 
   anchor { 'st2::bootstrap': }

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -449,6 +449,9 @@ class st2::profile::mistral(
           }
         }
       }
+      default: {
+          crit('unsupported init system, only Upstart, Systemd and Init are supported')
+      }
     }
 
     service { 'mistral':

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -19,7 +19,7 @@ class st2::profile::mongodb {
   include '::st2::params'
 
   if !defined(Class['::mongodb::server']) {
-    if $::osfamily == "RedHat" {
+    if $::osfamily == 'RedHat' {
       Yumrepo['epel']->
       class {'::mongodb::server': }->
       class {'::mongodb::client': }

--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -22,7 +22,7 @@ class st2::profile::rabbitmq {
     }
   }
 
-  if $::osfamily == "RedHat" {
+  if $::osfamily == 'RedHat' {
     class {'::erlang': }
 
     yumrepo { 'erlang-solutions':

--- a/manifests/profile/repos.pp
+++ b/manifests/profile/repos.pp
@@ -15,16 +15,16 @@
 #  include st2::profile::repos
 #
 class st2::profile::repos {
-  if $::osfamily == "RedHat" {
+  if $::osfamily == 'RedHat' {
     require epel
 
-    if $operatingsystemmajrelease == '6' {
+    if $::operatingsystemmajrelease == '6' {
       package{'ius-release':
-        ensure            => 'installed',
-        provider          => 'rpm',
-        source            => 'https://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-14.ius.centos6.noarch.rpm',
-        install_options   => '--nodeps',
-        require           => Yumrepo['epel']
+        ensure          => 'installed',
+        provider        => 'rpm',
+        source          => 'https://dl.iuscommunity.org/pub/ius/stable/CentOS/6/x86_64/ius-release-1.0-14.ius.centos6.noarch.rpm',
+        install_options => '--nodeps',
+        require         => Yumrepo['epel']
       }
     }
   }

--- a/manifests/rbac.pp
+++ b/manifests/rbac.pp
@@ -16,13 +16,13 @@
 define st2::rbac (
   $ensure      = 'present',
   $user        = $name,
-  $description = "Created and managed by Puppet",
+  $description = 'Created and managed by Puppet',
   $roles       = [],
 ) {
   $_rbac_dir = '/opt/stackstorm/rbac'
   $_enabled_state = $ensure ? {
-    'present' => 'true',
-    default   => 'false',
+    'present' => true,
+    default   => false,
   }
 
   ensure_resource('file', $_rbac_dir, {
@@ -55,7 +55,7 @@ define st2::rbac (
   })
   ensure_resource('exec', 'reload st2 rbac definitions', {
     'command'         => 'st2-apply-rbac-definitions',
-    'refreshonly'     => 'true',
+    'refreshonly'     => true,
     'path'            => '/usr/sbin:/usr/bin:/sbin:/bin',
   })
   file { "${_rbac_dir}/assignments/${user}.yaml":


### PR DESCRIPTION
This PR fixes the remainder of the puppet-lint issues identified by the test system.

Now that the module can properly complete a profile::fullinstall on a clean 14.04 container, what are the odds of getting a new version of the module pushed to Puppet Forge?
