### PR TITLE
Ensure /opt/stackstorm exists before installing st2web

### DIFF
--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -50,8 +50,8 @@ class st2::profile::fullinstall inherits st2 {
 
   Anchor['st2::pre_reqs']
   -> class { '::st2::profile::client': }
-  -> class { '::st2::profile::server': }
   -> class { '::st2::profile::web': }
+  -> class { '::st2::profile::server': }
 
   include ::st2::packs
   include ::st2::kvs

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -36,6 +36,7 @@ class st2::profile::web(
   }
 
   file { [
+      '/opt/stackstorm',
       '/opt/stackstorm/static',
       '/opt/stackstorm/static/webui',
     ]:


### PR DESCRIPTION
Without this, the web profile module is not guaranteed to be able to run successfully unless the server profile has run first.  This ordering was done previously in the fullinstall profile, but the catch is that the server profile tries to start everything before the web profile has run, so st2web fails to start because it hasn't been installed yet.

This PR runs the web profile before the server profile, adds the parent directory that the web profile needs so that it can complete successfully, and then follows that up with the server profile to start everything.

After this PR gets in, I can successfully go from a clean 14.04 container in LXC to a profile::fullinstall in one go with no issues.
