### PR TITLE
Updated CHANGELOG to reflect recent PRs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Development
+
+- Added new parameter `mongodb_manage_repo` to `::st2` so that the `mongodb` install
+  will not manage the repository files, allowing for installations from locally
+  cached repos. #184
+  Contributed by @ruriky
+  
+- Added new parameter `nginx_manage_repo` to `::st2` so that the `nginx` install
+  will not manage the repository files, allowing for installations from locally
+  cached repos. #182
+  Contributed by @ruriky
+  
+- Added more puppet-lint checks. #181
+  Contributed by @bdandoy
+
+- Added Slack notifications to https://stackstorm-community.slack.com #puppet-st2
+  for Travis build failures. #180
+  Contributed by @armab
+
 ## 1.0.0-beta (Aug 14, 2017)
 
 #### files/repo/nodesource/NODESOURCE-GPG-SIGNING-KEY-EL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Added more puppet-lint checks. #181
   Contributed by @bdandoy
 
-- Added Slack notifications to https://stackstorm-community.slack.com #puppet-st2
+- Added Slack notifications to https://stackstorm-community.slack.com `#puppet`
   for Travis build failures. #180
   Contributed by @armab
 


### PR DESCRIPTION
I've missed requiring PR submitters to update the CHANGELOG on a few recent PRs.

I've cleaned this up in this PR and will be sure to require CHANGELOG updates where appropriate in the future.