### PR TITLE
 Install and manage st2chatops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Added a new class `chatops` to manage the chatops package, service and configuration.
+  Added new parameters `chatops_adapter` and `chatops_adapter_conf` to `::st2` for allowing user to manage the hubot adapter packages and configuration. #187
+  Contributed by @ruriky
+
 - Added new parameter `mongodb_manage_repo` to `::st2` so that the `mongodb` install
   will not manage the repository files, allowing for installations from locally
   cached repos. #184

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ classes for use and configuration.
 * `st2::profile::rabbitmq` - st2 configured RabbitMQ installation
 * `st2::proflle::server` - st2 server components
 * `st2::profile::web` - st2 web components
+* `st2::profile::chatops` - st2 chatops components
 
 ### Installing and configuring Packs
 
@@ -107,6 +108,30 @@ st2::packs:
     config:
       post_message_action:
         webhook_url: XXX
+```
+
+### Configuring Hubot (ChatOps)
+
+Configuration via Hiera:
+```yaml
+  # install and configure rocketchat adapter
+
+  # install the rocketchat adapter (hash)
+  st2::chatops_adapter:
+    hubot-adapter:
+      package: 'hubot-rocketchat'
+      source: 'git+ssh://git@git.company.com:npm/hubot-rocketchat#master'
+
+  # adapter configuration
+  st2::chatops_adapter_config:
+    HUBOT_ADAPTER: rocketchat
+    ROCKETCHAT_URL: "https://chat.company.com:443"
+    ROCKETCHAT_ROOM: 'stackstorm'
+    LISTEN_ON_ALL_PUBLIC: true
+    ROCKETCHAT_USER: st2
+    ROCKETCHAT_PASSWORD: secret123
+    ROCKETCHAT_AUTH: password
+    RESPOND_TO_DM: true
 ```
 
 ## Known Limitations

--- a/README.md
+++ b/README.md
@@ -114,15 +114,13 @@ st2::packs:
 
 Configuration via Hiera:
 ```yaml
-  # install and configure rocketchat adapter
-
-  # install the rocketchat adapter (hash)
+  # install and configure hubot adapter (rocketchat, nodejs module installed by ::nodejs)
   st2::chatops_adapter:
     hubot-adapter:
       package: 'hubot-rocketchat'
       source: 'git+ssh://git@git.company.com:npm/hubot-rocketchat#master'
 
-  # adapter configuration
+  # adapter configuration (hash)
   st2::chatops_adapter_config:
     HUBOT_ADAPTER: rocketchat
     ROCKETCHAT_URL: "https://chat.company.com:443"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@
 #                            for mongodb
 #  [*nginx_manage_repo*]    - Set this to false when you have your own repositories for nginx
 #  [*chatops_adapter*]      - Adapter package(s) to be installed with npm. List of hashes.
-#  [*chatops_adapter_conf*] - List of configuration parameters for Hubot adapter
+#  [*chatops_adapter_conf*] - Configuration parameters for Hubot adapter (hash)
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,4 +108,6 @@ class st2(
   $datastore_keys_dir       = $::st2::params::datstore_keys_dir,
   $datastore_key_path       = "${::st2::params::datstore_keys_dir}/datastore_key.json",
   $nginx_manage_repo        = true,
+  $chatops_npm_packages     = {},
+  $chatops_adapter_config   = {},
 ) inherits st2::params {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,50 +5,52 @@
 #
 # === Parameters
 #
-#  [*version*]            - Version of StackStorm to install
-#  [*revision*]           - Revision of StackStorm to install
-#  [*autoupdate*]         - Automatically update to latest stable. (default: false)
-#  [*mistral_git_branch*] - Tagged branch of Mistral to download/install
-#  [*repo_env*]           - Specify the environment of package repo (production, staging)
-#  [*conf_file*]          - The path where st2 config is stored
-#  [*use_ssl*]            - Enable/Disable SSL for all st2 APIs
-#  [*ssl_key*]            - The path to SSL key for all st2 APIs
-#  [*ssl_cert*]           - The path to SSL cert for all st2 APIs
-#  [*api_url*]            - URL where the StackStorm API lives (default: undef)
-#  [*api_logging_file*]   - Path to st2 API logging file (default: /etc/st2api/logging.conf)
-#  [*auth*]               - Toggle to enable/disable auth (Default: false)
-#  [*auth_url*]           - URL where the StackStorm WebUI lives (default: undef)
-#  [*flow_url*]           - URL Path where StackStorm Flow lives (default: undef)
-#  [*cli_base_url*]       - CLI config - Base URL lives
-#  [*cli_api_version*]    - CLI config - API Version
-#  [*cli_debug*]          - CLI config - Enable/Disable Debug
-#  [*cli_cache_token*]    - CLI config - True to cache auth token until expries
-#  [*cli_username*]       - CLI config - Auth Username
-#  [*cli_password*]       - CLI config - Auth Password
-#  [*cli_api_url*]        - CLI config - API URL
-#  [*cli_auth_url*]       - CLI config - Auth URL
-#  [*global_env*]         - Globally set the environment variables for ST2 API/Auth
-#                           Overwritten by local config or CLI arguments.
-#  [*workers*]            - Set the number of actionrunner processes to start
-#  [*syslog*]             - Routes all log messages to syslog
-#  [*syslog_host*]        - Syslog host. Default: localhost
-#  [*syslog_protocol*]    - Syslog protocol. Default: udp
-#  [*syslog_port*]        - Syslog port. Default: 514
-#  [*syslog_facility*]    - Syslog facility. Default: local7
-#  [*ssh_key_location*]   - Location on filesystem of Admin SSH key for remote runner
-#  [*db_host*]            - Hostname to talk to st2 db
-#  [*db_port*]            - Port for db server for st2 to talk to
-#  [*db_bind_ips*]        - Array of bind IP addresses for MongoDB to listen on
-#  [*db_name*]            - Name of db to connect to (default: 'st2')
-#  [*db_username*]        - Username to connect to db with (default: 'stackstorm')
-#  [*db_password*]        - Password for 'admin' and 'stackstorm' users in MongDB.
-#                           If 'undef' then use $cli_password
-#  [*mongodb_version*]    - Version of MongoDB to install. If not provided it
-#                           will be auto-calcuated based on $version
-#                           (default: undef)
-#  [*mongodb_manage_repo*]- Set this to false when you have your own repositories
-#                           for mongodb
-#  [*nginx_manage_repo*]  - Set this to false when you have your own repositories for nginx
+#  [*version*]              - Version of StackStorm to install
+#  [*revision*]             - Revision of StackStorm to install
+#  [*autoupdate*]           - Automatically update to latest stable. (default: false)
+#  [*mistral_git_branch*]   - Tagged branch of Mistral to download/install
+#  [*repo_env*]             - Specify the environment of package repo (production, staging)
+#  [*conf_file*]            - The path where st2 config is stored
+#  [*use_ssl*]              - Enable/Disable SSL for all st2 APIs
+#  [*ssl_key*]              - The path to SSL key for all st2 APIs
+#  [*ssl_cert*]             - The path to SSL cert for all st2 APIs
+#  [*api_url*]              - URL where the StackStorm API lives (default: undef)
+#  [*api_logging_file*]     - Path to st2 API logging file (default: /etc/st2api/logging.conf)
+#  [*auth*]                 - Toggle to enable/disable auth (Default: false)
+#  [*auth_url*]             - URL where the StackStorm WebUI lives (default: undef)
+#  [*flow_url*]             - URL Path where StackStorm Flow lives (default: undef)
+#  [*cli_base_url*]         - CLI config - Base URL lives
+#  [*cli_api_version*]      - CLI config - API Version
+#  [*cli_debug*]            - CLI config - Enable/Disable Debug
+#  [*cli_cache_token*]      - CLI config - True to cache auth token until expries
+#  [*cli_username*]         - CLI config - Auth Username
+#  [*cli_password*]         - CLI config - Auth Password
+#  [*cli_api_url*]          - CLI config - API URL
+#  [*cli_auth_url*]         - CLI config - Auth URL
+#  [*global_env*]           - Globally set the environment variables for ST2 API/Auth
+#                             Overwritten by local config or CLI arguments.
+#  [*workers*]              - Set the number of actionrunner processes to start
+#  [*syslog*]               - Routes all log messages to syslog
+#  [*syslog_host*]          - Syslog host. Default: localhost
+#  [*syslog_protocol*]      - Syslog protocol. Default: udp
+#  [*syslog_port*]          - Syslog port. Default: 514
+#  [*syslog_facility*]      - Syslog facility. Default: local7
+#  [*ssh_key_location*]     - Location on filesystem of Admin SSH key for remote runner
+#  [*db_host*]              - Hostname to talk to st2 db
+#  [*db_port*]              - Port for db server for st2 to talk to
+#  [*db_bind_ips*]          - Array of bind IP addresses for MongoDB to listen on
+#  [*db_name*]              - Name of db to connect to (default: 'st2')
+#  [*db_username*]          - Username to connect to db with (default: 'stackstorm')
+#  [*db_password*]          - Password for 'admin' and 'stackstorm' users in MongDB.
+#                             If 'undef' then use $cli_password
+#  [*mongodb_version*]      - Version of MongoDB to install. If not provided it
+#                             will be auto-calcuated based on $version
+#                             (default: undef)
+#  [*mongodb_manage_repo*]  - Set this to false when you have your own repositories
+#                            for mongodb
+#  [*nginx_manage_repo*]    - Set this to false when you have your own repositories for nginx
+#  [*chatops_adapter*]      - Adapter package(s) to be installed with npm. List of hashes.
+#  [*chatops_adapter_conf*] - List of configuration parameters for Hubot adapter
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
 #
@@ -108,6 +110,6 @@ class st2(
   $datastore_keys_dir       = $::st2::params::datstore_keys_dir,
   $datastore_key_path       = "${::st2::params::datstore_keys_dir}/datastore_key.json",
   $nginx_manage_repo        = true,
-  $chatops_npm_packages     = {},
-  $chatops_adapter_config   = {},
+  $chatops_adapter          = $::st2::params::chatops_adapter,
+  $chatops_adapter_conf     = $::st2::params::chatops_adapter_conf,
 ) inherits st2::params {}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,4 +155,14 @@ class st2::params(
   $rabbitmq_port = 25672
   $rabbitmq_protocol = 'tcp'
   $rabbitmq_selinux_type = 'amqp_port_t'
+
+  ## chatops default config
+  $hubot_log_level = 'debug'
+  $hubot_express_port = '8081'
+  $tls_cert_reject_unauthorized = '0'
+  $hubot_name = 'hubot'
+  $chatops_adapter = {}
+  $chatops_adapter_conf = {}
+
+
 }

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -26,12 +26,12 @@
 
 class st2::profile::chatops (
   $version                      = $::st2::version,
-  $hubot_log_level              = 'debug',
-  $hubot_express_port           = '8081',
-  $tls_cert_reject_unauthorized = '0',
-  $hubot_name                   = 'hubot',
-  $npm_packages                 = $::st2::chatops_npm_packages,
-  $adapter_config               = $::st2::chatops_adapter_config,
+  $hubot_log_level              = $::st2::params::hubot_log_level,
+  $hubot_express_port           = $::st2::params::hubot_express_port,
+  $tls_cert_reject_unauthorized = $::st2::params::tls_cert_reject_unauthorized,
+  $hubot_name                   = $::st2::params::hubot_name,
+  $npm_packages                 = $::st2::chatops_adapter,
+  $adapter_config               = $::st2::chatops_adapter_conf,
 ) inherits st2 {
   include '::st2::params'
 

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -1,0 +1,91 @@
+# == Class: st2::profile::chatops
+#
+#  Profile to install and configure chatops for st2
+#
+# === Parameters
+#
+#  [*version*]                      - Version of StackStorm to install
+#  [*hubot_log_level*]              - Hubot log level
+#  [*hubot_express_port*]           - Express port hubot listens to
+#  [*tls_cert_reject_unauthorized*] - Set to 1 when using self signed certs
+#  [*hubot_name*]                   - Hubot's name
+#  [*npm_packages*]                 - Nodejs packages to be installed (hubot adapter)
+#  [*adapter_config*]               - Configuration for hubot adapter
+#
+# === Variables
+#
+#  [*_chatops_packages*] - Local scoped variable to store st2 chatops packages.
+#                          Sources from st2::params
+#  [*_chatops_dir*]      - Local scoped variable for full path of chatops directory.
+#  [*_chatops_env_file*] - Local scoped variable for full path of st2chatops env file.
+#
+# === Examples
+#
+#  include st2::profile::chatops
+#
+
+class st2::profile::chatops (
+  $version                      = $::st2::version,
+  $hubot_log_level              = 'debug',
+  $hubot_express_port           = '8081',
+  $tls_cert_reject_unauthorized = '0',
+  $hubot_name                   = 'hubot',
+  $npm_packages                 = $::st2::chatops_npm_packages,
+  $adapter_config               = $::st2::chatops_adapter_config,
+) inherits st2 {
+  include '::st2::params'
+
+  $_chatops_packages = $::st2::params::st2_chatops_packages
+  $_chatops_dir  = '/opt/stackstorm/chatops'
+  $_chatops_env_file = "${_chatops_dir}/st2chatops.env"
+
+  ########################################
+  ## Packages
+  package { $_chatops_packages:
+    ensure => $version,
+    tag    => 'st2::chatops::packages',
+  }
+
+  ########################################
+  ## Config
+  file { $_chatops_env_file:
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('st2/st2chatops.env.erb'),
+  }
+
+  ########################################
+  ## Additional nodejs packages
+  include ::st2::profile::nodejs
+
+  $npm_package_defaults = {
+    ensure  => present,
+    target  => $_chatops_dir,
+    require => Class['St2::Profile::Nodejs'],
+    tag     => 'st2::chatops::npm_package',
+  }
+
+  create_resources('nodejs::npm', $npm_packages, $npm_package_defaults)
+
+  ########################################
+  ## Services
+  service { $::st2::params::st2_chatops_services:
+    ensure => 'running',
+    enable => true,
+    tag    => 'st2::chatops::service',
+  }
+
+  ########################################
+  ## Dependencies
+  Package<| tag == 'st2::chatops::packages' |>
+  -> File[$_chatops_env_file]
+  ~> Service<| tag == 'st2::chatops::service' |> # notify to force a refresh
+
+  Service<| tag == 'st2::service' |>
+  -> Service<| tag == 'st2::chatops::service' |>
+
+  Nodejs::Npm<| tag == 'st2::chatops::npm_package' |>
+  -> Service<| tag == 'st2::chatops::service' |>
+}

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -10,7 +10,7 @@
 #  [*tls_cert_reject_unauthorized*] - Set to 1 when using self signed certs
 #  [*hubot_name*]                   - Hubot's name
 #  [*npm_packages*]                 - Nodejs packages to be installed (hubot adapter)
-#  [*adapter_config*]               - Configuration for hubot adapter
+#  [*adapter_config*]               - Configuration parameters for Hubot adapter (hash)
 #
 # === Variables
 #
@@ -67,7 +67,7 @@ class st2::profile::chatops (
     tag     => 'st2::chatops::npm_package',
   }
 
-  create_resources('nodejs::npm', $npm_packages, $npm_package_defaults)
+  create_resources('::nodejs::npm', $npm_packages, $npm_package_defaults)
 
   ########################################
   ## Services

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -36,6 +36,7 @@ class st2::profile::fullinstall inherits st2 {
   -> class { '::st2::profile::client': }
   -> class { '::st2::profile::server': }
   -> class { '::st2::profile::web': }
+  -> class { '::st2::profile::chatops': }
   -> Anchor['st2::end']
 
   # default pack

--- a/templates/st2chatops.env.erb
+++ b/templates/st2chatops.env.erb
@@ -1,0 +1,47 @@
+## This file is maintained by Puppet
+
+export ST2_HOSTNAME="${ST2_HOSTNAME:-localhost}"
+
+#####################################################################
+# Hubot settings
+
+# set if you don’t have a valid SSL certificate.
+export NODE_TLS_REJECT_UNAUTHORIZED=<%= @tls_cert_reject_unauthorized %>
+
+# Hubot port - must be accessible from StackStorm
+export EXPRESS_PORT=<%= @hubot_express_port %>
+
+# Log level
+export HUBOT_LOG_LEVEL=<%= @hubot_log_level %>
+
+# Bot name
+export HUBOT_NAME=<%= @hubot_name %>
+export HUBOT_ALIAS='!'
+
+######################################################################
+# StackStorm settings
+
+# StackStorm API endpoint.
+export ST2_API="${ST2_API:-https://${ST2_HOSTNAME}/api}"
+
+# StackStorm auth endpoint.
+export ST2_AUTH_URL="${ST2_AUTH_URL:-https://${ST2_HOSTNAME}/auth}"
+
+# StackStorm API key
+export ST2_API_KEY="${ST2_API_KEY}"
+
+# ST2 credentials. Fill in to use any stackstorm account.
+export ST2_AUTH_USERNAME="${ST2_AUTH_USERNAME:-st2admin}"
+export ST2_AUTH_PASSWORD="${ST2_AUTH_PASSWORD:-testp}"
+
+# Public URL of StackStorm instance: used it to offer links to execution details in a chat.
+export ST2_WEBUI_URL=https://${ST2_HOSTNAME}
+
+######################################################################
+# Chat service adapter settings
+
+<% unless @adapter_config.empty? %>
+<% @adapter_config.each do |key,value| %>
+export <%= key %>=<%= value%>
+<% end %>
+<% end %>


### PR DESCRIPTION
- Install needed packages
- Manage st2chatops.env file (hubot and adapter configuration)
- Install optional nodejs modules for hubot adapter
- Manage st2chatops service

Example hiera config for setting up hubot and rocketchat adapter:
```
st2::chatops_npm_packages:
  hubot-adapter:
    package: 'hubot-rocketchat'
    source: 'git+ssh://git@git.company.com:npm/hubot-rocketchat#master'
st2::chatops_adapter_config:
  HUBOT_ADAPTER: rocketchat
  ROCKETCHAT_URL: "https://test-chat.company.com:443"
  ROCKETCHAT_ROOM: 'sandbox'
  LISTEN_ON_ALL_PUBLIC: true
  ROCKETCHAT_USER: st2
  ROCKETCHAT_PASSWORD: xxxxxx
  ROCKETCHAT_AUTH: password
  RESPOND_TO_DM: true
```

I am successfully using this in my test env so it passes my use cases. Any comments are appreciated.