### PR TITLE
New type and provider for installing packs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Development
 
+- New type and provider for managing st2 packs: `st2_pack`.
+  Added new parameter `index_url` to `::st2` allowing custom st2 Exchange
+  index file location.
+  Profile `fullinstall` does not force installation of package `st2` anymore.
+
 - Added a new class `chatops` to manage the chatops package, service and configuration.
   Added new parameters `chatops_adapter` and `chatops_adapter_conf` to `::st2` for allowing user to manage the hubot adapter packages and configuration. #187
   Contributed by @ruriky

--- a/lib/puppet/provider/st2_pack/default.rb
+++ b/lib/puppet/provider/st2_pack/default.rb
@@ -1,0 +1,54 @@
+require 'json'
+
+Puppet::Type.type(:st2_pack).provide(:default) do
+    desc "Provides support for managing st2 packs"
+
+    commands :st2 => "/usr/bin/st2"
+
+    def list_installed_packs
+        token = st2_authenticate
+        output = st2('pack', 'list', '-a', 'name', '-j', '-t', token)
+        parse_output_json(output)
+    end
+
+    # Get admin token 
+    def st2_authenticate
+        # Reuse previous token
+        if @token
+            return @token
+        else
+            @token = st2('auth', resource[:user], '-t', '-p', resource[:password]).chomp
+        end
+    end
+
+    def create
+        token = st2_authenticate
+        if @resource[:source]
+            source = @resource[:source]
+        else
+            source = @resource[:name]
+        end
+        st2('pack', 'install', '-t', token, source)
+    end
+
+    def destroy
+        token = st2_authenticate
+        st2('pack', 'remove', '-t', token, @resource[:name])
+    end
+
+    def exists?
+        list_installed_packs.include?(@resource[:name])
+    end
+
+    # Return list of package names
+    def parse_output_json(raw)
+        result = []
+        my_hash = JSON.parse(raw)
+        my_hash.each do |pack|
+            result << pack['name']
+        end
+        debug("Installed packs: #{result}")
+        result
+    end
+end
+

--- a/lib/puppet/type/st2_pack.rb
+++ b/lib/puppet/type/st2_pack.rb
@@ -1,0 +1,23 @@
+Puppet::Type.newtype(:st2_pack) do
+    @doc = 'Manage st2 packs'
+
+    ensurable
+
+    newparam(:name) do
+        desc "Name of the pack."
+
+        isnamevar
+    end
+
+    newparam(:user) do
+        desc "St2 cli user"
+    end
+
+    newparam(:password) do
+        desc "St2 cli password"
+    end
+
+    newparam(:source) do
+        desc "Git URL for st2 pack"
+    end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@
 #  [*global_env*]           - Globally set the environment variables for ST2 API/Auth
 #                             Overwritten by local config or CLI arguments.
 #  [*workers*]              - Set the number of actionrunner processes to start
+#  [*packs*]                - Hash of st2 packages to be installed
+#  [*index_url*]            - Url to the StackStorm Exchange index file. (default undef)
 #  [*syslog*]               - Routes all log messages to syslog
 #  [*syslog_host*]          - Syslog host. Default: localhost
 #  [*syslog_protocol*]      - Syslog protocol. Default: udp
@@ -89,6 +91,8 @@ class st2(
   $cli_auth_url             = 'http://127.0.0.1:9100',
   $global_env               = false,
   $workers                  = 8,
+  $packs                    = {},
+  $index_url                = undef,
   $mistral_api_url          = undef,
   $mistral_api_port         = '8989',
   $mistral_api_service      = false,
@@ -112,4 +116,17 @@ class st2(
   $nginx_manage_repo        = true,
   $chatops_adapter          = $::st2::params::chatops_adapter,
   $chatops_adapter_conf     = $::st2::params::chatops_adapter_conf,
-) inherits st2::params {}
+) inherits st2::params {
+
+  ########################################
+  ## Control commands
+  exec {'/usr/bin/st2ctl reload --register-all':
+    tag         => 'st2::reload',
+    refreshonly => true,
+  }
+
+  exec {'/usr/bin/st2ctl reload --register-configs':
+    tag         => 'st2::register-configs',
+    refreshonly => true,
+  }
+}

--- a/manifests/packs.pp
+++ b/manifests/packs.pp
@@ -1,6 +1,6 @@
 # == Class: st2::packs
 #
-#  Automatically loads packs and their configs from Hiera
+#  Install and configure st2 packages
 #
 #  See st2::pack and st2::pack::config for usage
 #
@@ -12,7 +12,8 @@
 #
 #  include st2::packs
 #
-class st2::packs {
-  $_packs = hiera_hash('st2::packs', {})
-  create_resources('st2::pack', $_packs)
+class st2::packs (
+  $packs = $::st2::packs,
+){
+  create_resources('::st2::pack', $packs)
 }

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -39,11 +39,6 @@ class st2::profile::fullinstall inherits st2 {
   -> class { '::st2::profile::chatops': }
   -> Anchor['st2::end']
 
-  # default pack
-  if !defined(St2::Pack['st2']) {
-    st2::pack {'st2': }
-  }
-
   include ::st2::auth::standalone
   include ::st2::packs
   include ::st2::kvs

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -42,4 +42,9 @@ class st2::profile::fullinstall inherits st2 {
   include ::st2::auth::standalone
   include ::st2::packs
   include ::st2::kvs
+
+  # If user has not defined a pack "st2", install it from the Exchange.
+  if ! defined(St2::Pack['st2']) {
+    ensure_resource('st2::pack', 'st2', {'ensure' => 'present'})
+  }
 }

--- a/spec/defines/pack_spec.rb
+++ b/spec/defines/pack_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'helpers/fact_helper'
+
+describe "st2::pack" do
+
+  let(:title) { 'st2testpack' }
+  let(:facts) do
+    {
+    :operatingsystem => 'RedHat',
+    :osfamily => 'RedHat',
+    :operatingsystemmajrelease => '7',
+    }
+  end
+
+  it do
+    is_expected.to contain_file('/opt/stackstorm').with(
+      :ensure => 'directory',
+      :owner => 'root',
+      :group => 'root',
+      :mode => '0755'
+    )
+  end
+  it do
+    is_expected.to contain_file('/opt/stackstorm/configs').with(
+      :ensure => 'directory',
+      :owner => 'st2',
+      :group => 'root',
+      :mode => '0755'
+    )
+  end
+  it do
+    is_expected.to contain_file('/opt/stackstorm/packs').with(
+      :ensure => 'directory',
+      :owner => 'root',
+      :group => 'st2packs'
+    )
+  end
+  it do
+    is_expected.to contain_group('st2packs')
+  end
+
+  context "when declared with config" do
+    let(:params) {{
+      :repo_url   => 'https://git.company.com/repos/packs/pack.git',
+      :config   => {:foo => "bar"},
+    }}
+    it do
+      is_expected.to contain_st2_pack('st2testpack')
+    end
+
+    it do
+      is_expected.to contain_file('/opt/stackstorm/configs/st2testpack.yaml').with(
+        :ensure => 'file',
+        :owner => 'st2',
+        :group => 'root',
+        :mode => '0640'
+      )
+    end
+  end
+
+  context "when declared with default parameters" do
+    it do
+      is_expected.to contain_st2_pack('st2testpack').with(
+        :ensure => 'present',
+        :user => 'st2admin',
+        :password => 'Ch@ngeMe'
+      )
+    end
+  end
+
+  context "when declared with explicit source" do
+    let(:params) {{ 
+      :repo_url   => 'https://git.company.com/repos/packs/pack.git',
+    }}
+    it do
+      is_expected.to contain_st2_pack('st2testpack').with(
+        :ensure => 'present',
+        :user => 'st2admin',
+        :password => 'Ch@ngeMe',
+        :source => 'https://git.company.com/repos/packs/pack.git'
+      )
+    end
+  end
+
+  context "when declared with non-default user and password" do
+    let(:pre_condition) { 'class {"::st2": cli_password => "test_bar", cli_username => "test_foo"}' }
+    it do
+      is_expected.to contain_st2_pack('st2testpack').with(
+        :ensure => 'present',
+        :user => 'test_foo',
+        :password => 'test_bar'
+      )
+    end
+  end
+
+  context "when defining a package absent" do
+    let(:params) {{
+        :ensure  => 'absent',
+    }}
+    it do
+      is_expected.to contain_st2_pack('st2testpack').with(
+        :ensure => 'absent',
+        :user => 'st2admin',
+        :password => 'Ch@ngeMe'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Refactor st2 package installation to use new pack install commands.

- New parameters 'packs' in class '::st2' containing hash of st2 pack names and their configurations.
- New parameter 'index_url' in class '::st2' for providing optional st2 Exchange index file location (in case no internet connection)
- New type and provider st2_pack
- Refactor pack.pp to use st2_pack type
- Move control commands to ::st2 as there they can be used as a common sync points by all classes.
- Do not force installation of package 'st2'

I am successfully using this in my test env to install new packs from my internal git server. I have not tried to install any packages from the actual st2 Exchange. These changes should not break backward compatibility (existing ::st2::packs hiera configs should be ok). I am not sure how the current code works with authentication needed when using "st2 pack" commands. The new st2_pack type expects that there is authentication set and ::st2::cli_username and ::st2::cli_password are always passed to the command. This still needs some work.. 

Any comments are appreciated!