### PR TITLE
Bugfix/rhel6 build

### DIFF
--- a/.fixtures.rhel6.yml
+++ b/.fixtures.rhel6.yml
@@ -4,7 +4,12 @@ fixtures:
   forge_modules:
     apt: "puppetlabs/apt"
     concat: "puppetlabs/concat"
-    stdlib: "puppetlabs/stdlib"
+    stdlib:
+      # Lock stdlib at 4.22.0 because RHEL6 build fails on 4.23.0
+      # A bug has been submitted to puppetlabs:
+      # https://tickets.puppetlabs.com/browse/MODULES-6104
+      repo: "puppetlabs/stdlib"
+      ref: "4.22.0"
     httpauth: "jamtur01/httpauth"
     staging: "nanliu/staging"
     git: "maestrodev/git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,10 @@ fixtures:
   forge_modules:
     apt: "puppetlabs/apt"
     concat: "puppetlabs/concat"
-    stdlib: "puppetlabs/stdlib"
+    stdlib:
+      # lock at 4.22.0 because RHEL6 build fails on 4.23.0
+      repo: "puppetlabs/stdlib"
+      ref: "4.22.0"
     httpauth: "jamtur01/httpauth"
     staging: "nanliu/staging"
     git: "maestrodev/git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,9 @@ fixtures:
     apt: "puppetlabs/apt"
     concat: "puppetlabs/concat"
     stdlib:
-      # lock at 4.22.0 because RHEL6 build fails on 4.23.0
+      # Lock stdlib at 4.22.0 because RHEL6 build fails on 4.23.0
+      # A bug has been submitted to puppetlabs:
+      # https://tickets.puppetlabs.com/browse/MODULES-6104
       repo: "puppetlabs/stdlib"
       ref: "4.22.0"
     httpauth: "jamtur01/httpauth"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - BUILD_NAME="RHEL 6"
         - PUPPET_VERSION="~> 3.0"
         - GEMFILE_LOCK="Gemfile.lock.3.8.7.ruby1.8.7"
+        - FIXTURES_YML=".fixtures.rhel6.yml"
     - rvm: 2.0.0
       env:
         - BUILD_NAME="RHEL 7"


### PR DESCRIPTION
This locks puppetlabs/stdlib to 4.22.0.

The newest version of puppetlabs/stdlib, 4.23.0, changes a bunch of ruby functions to us the new hashing syntax which is not compatible with ruby < 2.0. Because of this change the RHEL 6 build broke (only cosmetic, but we like working builds).

This change locks puppetlabs/stdlib to 4.22.0 in the fixtures file that is used for the spec unit testing.

In the future it might be good to implement a build-dependent fixtures file.