### PR TITLE
Upgrade to MongoDB 3.4 and NodeJS 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Development
 
+- Upgraded NodeJS to 6.x when installing StackStorm >= 2.4.0.
+  Contributed by @nmaludy
+
+- Upgraded MongoDB to 3.4 when installing StackStorm >= 2.4.0.
+  If you're currently running a version of StackStorm 2.4.0 with MongoDB 3.2
+  installed, the repo will be updated to point at 3.4. 
+  To upgrade MongoDB go through the normal upgrade process on your system,
+  example for RHEL: `yum clean all; yum upgrade -y`
+  Contributed by @nmaludy
+
 - New type and provider for managing st2 packs: `st2_pack`.
   Added new parameter `index_url` to `::st2` allowing custom st2 Exchange
   index file location.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Development
 
 - Upgraded NodeJS to 6.x when installing StackStorm >= 2.4.0.
+  If you're currently running a version of StackStorm 2.4.0 with NodeJS 4.x
+  installed, the repo will be updated to point at 6.x. 
+  To upgrade NodeJS go through the normal upgrade process on your system,
+  example for RHEL: `yum clean all; yum upgrade -y`
   Contributed by @nmaludy
 
 - Upgraded MongoDB to 3.4 when installing StackStorm >= 2.4.0.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,10 +49,16 @@
 #                             will be auto-calcuated based on $version
 #                             (default: undef)
 #  [*mongodb_manage_repo*]  - Set this to false when you have your own repositories
-#                            for mongodb
+#                             for MongoDB (default: true)
 #  [*nginx_manage_repo*]    - Set this to false when you have your own repositories for nginx
+#                             (default: true)
 #  [*chatops_adapter*]      - Adapter package(s) to be installed with npm. List of hashes.
 #  [*chatops_adapter_conf*] - Configuration parameters for Hubot adapter (hash)
+#  [*nodejs_version*]       - Version of NodeJS to install. If not provided it
+#                             will be auto-calcuated based on $version
+#                             (default: undef)
+#  [*nodejs_manage_repo*]   - Set this to false when you have your own repositories
+#                             for NodeJS (default: true)
 #
 #  Variables can be set in Hiera and take advantage of automatic data bindings:
 #
@@ -116,6 +122,8 @@ class st2(
   $nginx_manage_repo        = true,
   $chatops_adapter          = $::st2::params::chatops_adapter,
   $chatops_adapter_conf     = $::st2::params::chatops_adapter_conf,
+  $nodejs_version           = undef,
+  $nodejs_manage_repo       = true,
 ) inherits st2::params {
 
   ########################################

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -43,7 +43,7 @@ class st2::profile::chatops (
   ## Packages
   package { $_chatops_packages:
     ensure => $version,
-    tag    => 'st2::chatops::packages',
+    tag    => ['st2::packages', 'st2::chatops::packages'],
   }
 
   ########################################

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -56,7 +56,7 @@ class st2::profile::mistral(
 
   package { $st2::params::st2_mistral_packages:
     ensure => $version,
-    tag    => 'st2::mistral::packages',
+    tag    => ['st2::packages', 'st2::mistral::packages'],
   }
   ### End Mistral Packages ###
 

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -24,13 +24,13 @@
 #  include st2::profile::mongodb
 #
 class st2::profile::mongodb (
-  $db_name     = $st2::db_name,
-  $db_username = $st2::db_username,
-  $db_password = $st2::db_password,
-  $db_port     = $st2::db_port,
-  $db_bind_ips = $st2::db_bind_ips,
-  $version     = $st2::mongodb_version,
-  $manage_repo = $st2::mongodb_manage_repo,
+  $db_name     = $::st2::db_name,
+  $db_username = $::st2::db_username,
+  $db_password = $::st2::db_password,
+  $db_port     = $::st2::db_port,
+  $db_bind_ips = $::st2::db_bind_ips,
+  $version     = $::st2::mongodb_version,
+  $manage_repo = $::st2::mongodb_manage_repo,
 ) inherits st2 {
 
   # if the StackStorm version is 'latest' or >= 2.4.0 then use MongoDB 3.4
@@ -45,12 +45,12 @@ class st2::profile::mongodb (
   # if user specified a version of MongoDB they want to use, then use that
   # otherwise use the default version of mongo based off the StackStorm version
   $mongodb_version = $version ? {
-    undef    => $mongodb_version_default,
-    default  => $version,
+    undef   => $mongodb_version_default,
+    default => $version,
   }
 
   $mongo_db_password = $db_password ? {
-    undef   => $st2::cli_password,
+    undef   => $::st2::cli_password,
     default => $db_password,
   }
 
@@ -71,7 +71,7 @@ class st2::profile::mongodb (
       port           => $db_port,
       create_admin   => true,
       store_creds    => true,
-      admin_username => $st2::params::mongodb_admin_username,
+      admin_username => $::st2::params::mongodb_admin_username,
       admin_password => $mongo_db_password,
     }
 
@@ -130,7 +130,7 @@ class st2::profile::mongodb (
     mongodb::db { $db_name:
       user     => $db_username,
       password => $mongo_db_password,
-      roles    => $st2::params::mongodb_st2_roles,
+      roles    => $::st2::params::mongodb_st2_roles,
       require  => Class['::mongodb::server'],
     }
   }

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -33,12 +33,20 @@ class st2::profile::mongodb (
   $manage_repo = $st2::mongodb_manage_repo,
 ) inherits st2 {
 
+  # if the StackStorm version is 'latest' or >= 2.4.0 then use MongoDB 3.4
+  # else use MongoDB 3.2
+  if $::st2::version == 'latest' or versioncmp($::st2::version, '2.4.0') >= 0 {
+    $mongodb_version_default = '3.4'
+  }
+  else {
+    $mongodb_version_default = '3.2'
+  }
+
   # if user specified a version of MongoDB they want to use, then use that
-  # otherwise auto-determine the version to use (as of st2 v2.3 MongoDB = 3.2)
-  # TODO in the future use semantic version compare against $st2::version
+  # otherwise use the default version of mongo based off the StackStorm version
   $mongodb_version = $version ? {
-    undef   => '3.2',
-    default => $version,
+    undef    => $mongodb_version_default,
+    default  => $version,
   }
 
   $mongo_db_password = $db_password ? {

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -36,20 +36,20 @@ class st2::profile::mongodb (
   # if the StackStorm version is 'latest' or >= 2.4.0 then use MongoDB 3.4
   # else use MongoDB 3.2
   if $::st2::version == 'latest' or versioncmp($::st2::version, '2.4.0') >= 0 {
-    $mongodb_version_default = '3.4'
+    $_mongodb_version_default = '3.4'
   }
   else {
-    $mongodb_version_default = '3.2'
+    $_mongodb_version_default = '3.2'
   }
 
   # if user specified a version of MongoDB they want to use, then use that
   # otherwise use the default version of mongo based off the StackStorm version
-  $mongodb_version = $version ? {
-    undef   => $mongodb_version_default,
+  $_mongodb_version = $version ? {
+    undef   => $_mongodb_version_default,
     default => $version,
   }
 
-  $mongo_db_password = $db_password ? {
+  $_mongo_db_password = $db_password ? {
     undef   => $::st2::cli_password,
     default => $db_password,
   }
@@ -59,7 +59,7 @@ class st2::profile::mongodb (
     class { '::mongodb::globals':
       manage_package      => true,
       manage_package_repo => $manage_repo,
-      version             => $mongodb_version,
+      version             => $_mongodb_version,
       bind_ip             => $db_bind_ips,
       manage_pidfile      => false, # mongo will not start if this is true
     }
@@ -72,7 +72,7 @@ class st2::profile::mongodb (
       create_admin   => true,
       store_creds    => true,
       admin_username => $::st2::params::mongodb_admin_username,
-      admin_password => $mongo_db_password,
+      admin_password => $_mongo_db_password,
     }
 
     Class['mongodb::globals']
@@ -129,7 +129,7 @@ class st2::profile::mongodb (
     # configure st2 database
     mongodb::db { $db_name:
       user     => $db_username,
-      password => $mongo_db_password,
+      password => $_mongo_db_password,
       roles    => $::st2::params::mongodb_st2_roles,
       require  => Class['::mongodb::server'],
     }

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -40,7 +40,15 @@ class st2::profile::nodejs(
     default => $version,
   }
 
-  if $::osfamily == 'RedHat'and versioncmp($::operatingsystemmajrelease, '6') == 0 {
+  if $::osfamily == 'RedHat' {
+    # Red Hat 7.x + already have NodeJS 6.x+ installed
+    # trying to install from nodesource repos fails, so just use the builtin
+    if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+      class { '::nodejs':
+        manage_package_repo => false,
+        npm_package_ensure  => 'present',
+      }
+    }
     # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)
     # In this old repo they hard-code some verifications about which versions
     # are allowed to be installed (at the time the module was released).

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -19,7 +19,7 @@
 #
 #  include st2::profile::nodejs
 #
-class st2::profile::nodejs,
+class st2::profile::nodejs(
   $manage_repo = $::st2::nodejs_manage_repo,
   $version     = $::st2::nodejs_version,
 ) inherits st2 {

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -5,7 +5,11 @@
 #
 # === Parameters
 #
-#  This module contains no parameters
+#  [*version*]     - Version of NodeJS to install. If not provided it
+#                    will be auto-calcuated based on $version
+#                    (default: $::st2::nodejs_version)
+#  [*manage_repo*] - Set this to false when you have your own repositories
+#                    for NodeJS (default: $::st2::nodejs_manage_repo)
 #
 # === Variables
 #
@@ -15,15 +19,39 @@
 #
 #  include st2::profile::nodejs
 #
-class st2::profile::nodejs {
+class st2::profile::nodejs,
+  $manage_repo = $::st2::nodejs_manage_repo,
+  $version     = $::st2::nodejs_version,
+) inherits st2 {
+
+  # if the StackStorm version is 'latest' or >= 2.4.0 then use NodeJS 6.x
+  # else use MongoDB 4.x
+  if $::st2::version == 'latest' or versioncmp($::st2::version, '2.4.0') >= 0 {
+    $nodejs_version_default = '6.x'
+  }
+  else {
+    $nodejs_version_default = '4.x'
+  }
+
+  # if user specified a version of NodeJS they want to use, then use that
+  # otherwise use the default version based off the StackStorm version
+  $nodejs_version = $version ? {
+    undef   => $nodejs_version_default,
+    default => $version,
+  }
+
   if $::osfamily == 'RedHat' {
     # Red Hat 7.x + already have NodeJS 6.x+ installed
     # trying to install from nodesource repos fails, so just use the builtin
     if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
       class { '::nodejs':
-        manage_package_repo => false,
-        npm_package_ensure  => 'present',
+        repo_url_suffix     => $nodejs_version,
+        manage_package_repo => $manage_repo,
       }
+      # class { '::nodejs':
+      #   manage_package_repo => false,
+      #   npm_package_ensure  => 'present',
+      # }
     }
     # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)
     # In this old repo they hard-code some verifications about which versions
@@ -34,15 +62,17 @@ class st2::profile::nodejs {
     # to avoid their verification checks (ugh...).
     else {
       class { '::nodejs':
-        repo_url_suffix => '4.x',
-        repo_class      => 'nodejs::repo::nodesource',
+        repo_url_suffix     => $nodejs_version,
+        repo_class          => 'nodejs::repo::nodesource',
+        manage_package_repo => $manage_repo,
       }
     }
   }
   else {
-    # else install nodejs 4.x from nodesource repo
+    # else install nodejs from nodesource repo
     class { '::nodejs':
-      repo_url_suffix => '4.x',
+      repo_url_suffix     => $nodejs_version,
+      manage_package_repo => $manage_repo,
     }
   }
 }

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -40,19 +40,7 @@ class st2::profile::nodejs(
     default => $version,
   }
 
-  if $::osfamily == 'RedHat' {
-    # Red Hat 7.x + already have NodeJS 6.x+ installed
-    # trying to install from nodesource repos fails, so just use the builtin
-    if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
-      class { '::nodejs':
-        repo_url_suffix     => $nodejs_version,
-        manage_package_repo => $manage_repo,
-      }
-      # class { '::nodejs':
-      #   manage_package_repo => false,
-      #   npm_package_ensure  => 'present',
-      # }
-    }
+  if $::osfamily == 'RedHat'and versioncmp($::operatingsystemmajrelease, '6') == 0 {
     # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)
     # In this old repo they hard-code some verifications about which versions
     # are allowed to be installed (at the time the module was released).
@@ -60,12 +48,10 @@ class st2::profile::nodejs(
     # RHEL 6.x. To fake this out we need to hard code the "repo_class"
     # to the same thing they use internally but without the leading "::"
     # to avoid their verification checks (ugh...).
-    else {
-      class { '::nodejs':
-        repo_url_suffix     => $nodejs_version,
-        repo_class          => 'nodejs::repo::nodesource',
-        manage_package_repo => $manage_repo,
-      }
+    class { '::nodejs':
+      repo_url_suffix     => $nodejs_version,
+      repo_class          => 'nodejs::repo::nodesource',
+      manage_package_repo => $manage_repo,
     }
   }
   else {

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -83,7 +83,7 @@ class st2::profile::server (
 
   package { $_server_packages:
     ensure => $version,
-    tag    => 'st2::server::packages',
+    tag    => ['st2::packages', 'st2::server::packages'],
   }
 
   ensure_resource('file', '/opt/stackstorm', {

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -29,7 +29,7 @@ class st2::profile::web(
   ## Install the packages
   package { $st2::params::st2_web_packages:
     ensure => $version,
-    tag    => 'st2::web::packages',
+    tag    => ['st2::packages', 'st2::web::packages'],
   }
 
   ## Create ssl cert directory

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
       "version_requirement": ">= 1.2.0"
     },
     {
-      "name": "puppetlabs/mongodb",
+      "name": "puppet/mongodb",
       "version_requirement": ">= 0.14.0"
     },
     {


### PR DESCRIPTION
Closes #170, closes #177

This upgrades the puppet module to install MongoDB 3.4 (#170) and NodeJS 6.x (#177) if installing StackStorm >= 2.4.0