### PR TITLE
Migrate to voxpupuli/rabbitmq module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Migrated to voxpupuli puppet/rabbitmq module and puppet/mongodb modules as
+  the puppetlabs/rabbitmq and puppetlabs/mongodb modules are deprecated.
+  Contributed by @nmaludy
+
 - Upgraded NodeJS to 6.x when installing StackStorm >= 2.4.0.
   If you're currently running a version of StackStorm 2.4.0 with NodeJS 4.x
   installed, the repo will be updated to point at 6.x. 

--- a/docs/Puppetfile
+++ b/docs/Puppetfile
@@ -19,7 +19,7 @@ mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppetlabs/mongodb', '0.17.0'
 mod 'puppetlabs/postgresql', '4.9.0'
-mod 'puppetlabs/rabbitmq'
+mod 'puppet/rabbitmq', '5.6.0' # 5.6.0 for puppet 3 support (last available version)
 mod 'puppetlabs/vcsrepo', '1.5.0'
 mod 'jfryman/tiller'
 mod 'stahnma/epel'
@@ -27,8 +27,9 @@ mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
 mod "puppet/selinux", "0.8.0"
 mod 'puppet/nginx', '0.6.0'
-mod 'puppet/nodejs', '2.3.0'
+mod 'puppet/nodejs', '2.3.0' # 2.3.0 for puppet 3 support (last available version)
+#mod 'puppet/nodejs', '1.3.0' # 1.3.0 for RHEL 6 support (ruby 1.8.7 w/ puppet 3.x
 
 mod 'stackstorm/st2',
-    :git => 'https://github.com/EncoreTechnologies/puppet-st2.git',
+    :git => 'https://github.com/StackStorm/puppet-st2.git',
     :branch => 'master'

--- a/docs/Puppetfile
+++ b/docs/Puppetfile
@@ -19,7 +19,7 @@ mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppetlabs/mongodb', '0.17.0'
 mod 'puppetlabs/postgresql', '4.9.0'
-mod 'puppet/rabbitmq', '5.6.0' # 5.6.0 for puppet 3 support (last available version)
+mod 'puppet/rabbitmq', '5.6.1' # 5.6.1 for puppet 3 support (last available version)
 mod 'puppetlabs/vcsrepo', '1.5.0'
 mod 'jfryman/tiller'
 mod 'stahnma/epel'

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -49,17 +49,19 @@ class st2::profile::nodejs(
         npm_package_ensure  => 'present',
       }
     }
-    # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)
-    # In this old repo they hard-code some verifications about which versions
-    # are allowed to be installed (at the time the module was released).
-    # This has changed and NodeJS 4.x is supported and can be installed on
-    # RHEL 6.x. To fake this out we need to hard code the "repo_class"
-    # to the same thing they use internally but without the leading "::"
-    # to avoid their verification checks (ugh...).
-    class { '::nodejs':
-      repo_url_suffix     => $nodejs_version,
-      repo_class          => 'nodejs::repo::nodesource',
-      manage_package_repo => $manage_repo,
+    else {
+      # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)
+      # In this old repo they hard-code some verifications about which versions
+      # are allowed to be installed (at the time the module was released).
+      # This has changed and NodeJS 4.x is supported and can be installed on
+      # RHEL 6.x. To fake this out we need to hard code the "repo_class"
+      # to the same thing they use internally but without the leading "::"
+      # to avoid their verification checks (ugh...).
+      class { '::nodejs':
+        repo_url_suffix     => $nodejs_version,
+        repo_class          => 'nodejs::repo::nodesource',
+        manage_package_repo => $manage_repo,
+      }
     }
   }
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
       "version_requirement": ">= 4.4.2"
     },
     {
-      "name": "puppetlabs/rabbitmq",
+      "name": "puppet/rabbitmq",
       "version_requirement": ">= 4.1.0"
     },
     {


### PR DESCRIPTION
Updated our metadata.json to the new voxpupuli repo for both rabbitmq and mongodb, closes #186 .

Also fixed a bug in mongodb profile that i introduced accidentally in my last PR.