### PR TITLE
Lock puppetlabs/inifile for RHEL6 builds

### DIFF
--- a/.fixtures.rhel6.yml
+++ b/.fixtures.rhel6.yml
@@ -17,7 +17,10 @@ fixtures:
     sudo: "saz/sudo"
     python: "stankevich/python"
     gcc: "puppetlabs/gcc"
-    inifile: "puppetlabs/inifile"
+    inifile:
+      # Lock inifile at 1.6.0 because 2.0.0+ drops support for puppet 3.x
+      repo: "puppetlabs/inifile"
+      ref: "1.6.0"
     mongodb: "puppetlabs/mongodb"
     mysql: "puppetlabs/mysql"
     rabbitmq: "puppetlabs/rabbitmq"


### PR DESCRIPTION
puppetlabs/inifile module dropped support for Ruby < 2.0 and Puppet 3.x in a release earlier this week.

This change locks the module to an old version that is compatible with our legacy RHEL 6 build.