### PR TITLE
Set MongoDB port to integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Changed the MongoDB port value from a String to an Integer. This makes it
+  compatible with the latest version of the `puppet-mongodb` module in Puppet 4
+  and Puppet 5. (Bugfix)
+  Contributed by @nmaludy
 
 ## 1.0.0-rc (Dec 19, 2017)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,7 +144,7 @@ class st2::params(
   ## MongoDB Data
   $mongodb_admin_username = 'admin'
 
-  $mongodb_port = '27017'
+  $mongodb_port = 27017
   $mongodb_bind_ips = ['127.0.0.1']
 
   $mongodb_st2_db = 'st2'


### PR DESCRIPTION
In the latest version of MongoDB module they enforced the `port` must be an integer, we had it set to a string causing a build failure in Puppet 4 & 5.

This simply changes our value for the MongoDB port to an integer in `::st2::params`