### PR TITLE
Locked the public_suffix gem for CentOS7 build using ruby 2.0

### DIFF
--- a/build/centos7/Gemfile
+++ b/build/centos7/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'coveralls'
 gem 'metadata-json-lint'
+gem 'public_suffix',                                             '~> 2.0' # 3.0.0 requires ruby 2.1+
 gem 'puppet',                                                    '~> 3.0' # 3.8.7
 gem 'puppet-blacksmith',                                         '>= 3.1.1'
 gem 'puppet-lint',                                               '>= 0.3.2'

--- a/build/centos7/Gemfile.lock
+++ b/build/centos7/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -17,22 +19,28 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.1.0)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     json_pure (2.1.0)
     metaclass (0.0.4)
+    metadata-json-lint (2.0.2)
+      json-schema (~> 2.8)
+      spdx-licenses (~> 1.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     netrc (0.11.0)
+    public_suffix (2.0.5)
     puppet (3.8.7)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-    puppet-blacksmith (4.0.1)
+    puppet-blacksmith (4.1.2)
       rest-client (~> 2.0)
     puppet-lint (2.3.3)
-    puppet-lint-absolute_classname-check (0.2.4)
+    puppet-lint-absolute_classname-check (0.2.5)
       puppet-lint (>= 1.0, < 3.0)
     puppet-lint-absolute_template_path (1.0.1)
       puppet-lint (>= 1.1, < 3.0)
@@ -48,7 +56,7 @@ GEM
       puppet-lint (>= 1.0, < 3.0)
     puppet-lint-leading_zero-check (0.1.1)
       puppet-lint (>= 1.0, < 3.0)
-    puppet-lint-resource_reference_syntax (1.0.10)
+    puppet-lint-resource_reference_syntax (1.0.14)
       puppet-lint (>= 1.0, < 3.0)
     puppet-lint-trailing_comma-check (0.3.2)
       puppet-lint (>= 1.0, < 3.0)
@@ -58,7 +66,7 @@ GEM
       puppet-lint (>= 1.0, < 3.0)
     puppet-syntax (2.4.1)
       rake
-    puppetlabs_spec_helper (2.5.1)
+    puppetlabs_spec_helper (2.6.1)
       mocha (~> 1.0)
       puppet-lint (~> 2.0)
       puppet-syntax (~> 2.0)
@@ -72,7 +80,7 @@ GEM
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -88,10 +96,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    spdx-licenses (1.1.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thor (0.19.4)
-    tins (1.15.1)
+    tins (1.16.3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -101,6 +110,8 @@ PLATFORMS
 
 DEPENDENCIES
   coveralls
+  metadata-json-lint
+  public_suffix (~> 2.0)
   puppet (~> 3.0)
   puppet-blacksmith (>= 3.1.1)
   puppet-lint (>= 0.3.2)


### PR DESCRIPTION
We've had a couple of random build failures for CentOS 7 in `cron` due to Bundler resolving gems in a weird way. In public_suffix `3.0.0+` Ruby 2.1+ is required, that was breaking the build. This locks the `public_suffix` gem for the CentOS 7 build to the `~> 2.0.0` meaning `< 3.0.0`. 

