### PR TITLE
Locked version of saz/sudo module

### DIFF
--- a/build/centos6/Puppetfile
+++ b/build/centos6/Puppetfile
@@ -15,7 +15,7 @@ mod 'jamtur01/httpauth'
 mod 'puppet/staging',        '1.0.7'
 mod 'puppetlabs/apt',   '2.4.0'
 mod 'maestrodev/wget'
-mod 'saz/sudo'
+mod 'saz/sudo',         '4.2.0' # for puppet 3 support (last available version)
 mod 'stankevich/python'
 mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile', '1.6.0'  # for RHEL 6 support (ruby 1.8.7 w/ puppet 3.x

--- a/build/centos7/Puppetfile
+++ b/build/centos7/Puppetfile
@@ -15,7 +15,7 @@ mod 'jamtur01/httpauth'
 mod 'puppet/staging',        '1.0.7'
 mod 'puppetlabs/apt',   '2.4.0'
 mod 'maestrodev/wget'
-mod 'saz/sudo'
+mod 'saz/sudo',         '4.2.0' # for puppet 3 support (last available version)
 mod 'stankevich/python'
 mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'

--- a/build/ubuntu14/Puppetfile
+++ b/build/ubuntu14/Puppetfile
@@ -15,7 +15,7 @@ mod 'jamtur01/httpauth'
 mod 'puppet/staging',        '1.0.7'
 mod 'puppetlabs/apt',   '2.4.0'
 mod 'maestrodev/wget'
-mod 'saz/sudo'
+mod 'saz/sudo',         '4.2.0' # for puppet 3 support (last available version)
 mod 'stankevich/python'
 mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'

--- a/build/ubuntu16/Puppetfile
+++ b/build/ubuntu16/Puppetfile
@@ -15,7 +15,7 @@ mod 'jamtur01/httpauth'
 mod 'puppet/staging',        '1.0.7'
 mod 'puppetlabs/apt',   '2.4.0'
 mod 'maestrodev/wget'
-mod 'saz/sudo'
+mod 'saz/sudo',         '4.2.0' # for puppet 3 support (last available version)
 mod 'stankevich/python'
 mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'


### PR DESCRIPTION
Latest version of the saz/sudo module dropped support for Puppet 3.x. This PR locks the version of that module to the latest puppet 3 supported version for our puppet 3 builds.