### PR TITLE
Stop Puppet from auto-updating 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@
   GitHub page. The following backends are supported: `flat_file` (default),
   `keystone`, `ldap`, `mongodb`, `pam`. (Feature)
   Contributed by @nmaludy
-- Fixed a bug where the `st2` packages were automatically updating due to
-  the package resources having `ensure => latest` set. Going forward, packages
-  will have `ensure => present` set and it will be the responsibility of the end
-  user to update the packages. (Bugfix)
+- Changed the behavior of `st2` packages. Previously they were automatically 
+  updating due to the package resources having `ensure => latest` set. Going
+  forward, packages will have `ensure => present` set by default  and it will be
+  the responsibility of the end user to update the packages. (Change)
   Contributed by @nmaludy
 
 ## 1.0.0-rc2 (Jan 9, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   GitHub page. The following backends are supported: `flat_file` (default),
   `keystone`, `ldap`, `mongodb`, `pam`. (Feature)
   Contributed by @nmaludy
+- Fixed a bug where the `st2` packages were automatically updating due to
+  the package resources having `ensure => latest` set. Going forward, packages
+  will have `ensure => present` set and it will be the responsibility of the end
+  user to update the packages. (Bugfix)
+  Contributed by @nmaludy
 
 ## 1.0.0-rc2 (Jan 9, 2018)
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ and [librarian-puppet](http://librarian-puppet.com/).
  * Ubuntu 14.04 - [build/ubuntu14/Puppetfile](build/ubuntu14/Puppetfile)
  * Ubuntu 16.06 [build/ubuntu16/Puppetfile](build/ubuntu16/Puppetfile)
 
+## Upgrading StackStorm
+
+By default this module does NOT handle upgrades of StackStorm. It is the 
+responsiblity of the end user to upgrade StackStorm according to the 
+[upgrade documenation](https://docs.stackstorm.com/install/upgrades.html).
+
+In a future release a Puppet task may be included to perform these update 
+on demand using [bolt](https://github.com/puppetlabs/bolt).
+
 ## Known Limitations
 
 ### MongoDB (Puppet < 4.0)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ or use to compose your own site-specific profile for StackStorm installation.
 Configuration can be done directly via code composition, or set via
 Hiera data bindings. A few notable parameters to take note of:
 
-* `st2::version` - Version of ST2 to install. (Latest version w/o value)
+* `st2::version` - Version of ST2 to install. This will be set as the `ensure`
+  value on the `st2` packages. The default is `present` resulting in the most
+  up to date packages being installed initially. If you would like to hard code
+  to an older version you can specify that here (ex: `2.6.0`).
+  **Note** Setting this to `latest` is NOT recommended. It will cause the 
+  StackStorm packages to be automatically updated without the proper upgrade steps
+  being taken (proper steps detailed here: https://docs.stackstorm.com/install/upgrades.html)
 
 All other classes are documented with Puppetdoc. Please refer to specific
 classes for use and configuration.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,13 +1,11 @@
 # TODO List for this project
 
-- Install and configure st2chatops
 - Reorganization effort
   - Migrate to a "modern" puppet model like: https://github.com/puppetlabs/puppetlabs-postgresql
   - All things in st2::profiles::xxx move to st2
   - Create sub folders for each "profile" (server, client, etc)
   - Decompose each "profile" into its parts (config, repo, install, service, etc)
   - Decompose "server" profile into each st2 component (st2actionrunner, st2api, etc)
-- Ability to install different st2 versions
 - Remove unused code
   - Tiller
   - Unused variables in this like st2::params
@@ -18,4 +16,12 @@
 - Play around with Beaker testing (in an effort to get this to be an "Approved" module)
 - More developer docs
 - More documentation for end users and a complete "Getting Started" guide
+  - end-to-end documentation 
+  - setup r10k
+  - download modules
+  - install puppet
+  - puppet apply
 - For PAM auth backend, configure `st2auth` service to run as root
+- Bolt Task for upgrading StackStorm
+- Tasks for various CLI commands
+- Proper provider implementation for key/value pairs

--- a/manifests/auth/keystone.pp
+++ b/manifests/auth/keystone.pp
@@ -54,7 +54,7 @@ class st2::auth::keystone (
 
   # install the backend package
   python::pip { 'st2-auth-backend-keystone':
-    ensure     => 'latest',
+    ensure     => present,
     pkgname    => 'st2-auth-backend-keystone',
     url        => 'git+https://github.com/StackStorm/st2-auth-backend-keystone.git@master#egg=st2_auth_backend_keystone',
     owner      => 'root',

--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -150,7 +150,7 @@ class st2::auth::ldap (
 
   # install the backend package
   python::pip { 'st2-auth-backend-ldap':
-    ensure     => 'latest',
+    ensure     => present,
     pkgname    => 'st2-auth-backend-ldap',
     url        => 'git+https://github.com/StackStorm/st2-auth-backend-ldap.git@master#egg=st2_auth_backend_ldap',
     owner      => 'root',

--- a/manifests/auth/mongodb.pp
+++ b/manifests/auth/mongodb.pp
@@ -71,7 +71,7 @@ class st2::auth::mongodb (
 
   # install the backend package
   python::pip { 'st2-auth-backend-mongodb':
-    ensure     => 'latest',
+    ensure     => present,
     pkgname    => 'st2-auth-backend-mongodb',
     url        => 'git+https://github.com/StackStorm/st2-auth-backend-mongodb.git@master#egg=st2_auth_backend_mongodb',
     owner      => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,9 @@
 #
 # === Parameters
 #
-#  [*version*]              - Version of StackStorm to install
-#  [*revision*]             - Revision of StackStorm to install
-#  [*autoupdate*]           - Automatically update to latest stable. (default: false)
+#  [*version*]              - Version of StackStorm package to install (default = 'present')
+#                             See the package 'ensure' property:
+#                             https://puppet.com/docs/puppet/5.5/types/package.html#package-attribute-ensure
 #  [*mistral_git_branch*]   - Tagged branch of Mistral to download/install
 #  [*repo_env*]             - Specify the environment of package repo (production, staging)
 #  [*conf_file*]            - The path where st2 config is stored
@@ -116,8 +116,7 @@
 #    st2::version: 0.6.0
 #
 class st2(
-  $version                  = 'latest',
-  $autoupdate               = false,
+  $version                  = 'present',
   $mistral_git_branch       = 'st2-1.2.0',
   $repo_base                = $::st2::params::repo_base,
   $repo_env                 = $::st2::params::repo_env,

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -4,7 +4,6 @@
 #
 # === Parameters
 #
-#  [*version*]              - Version of StackStorm to install
 #  [*base_url*]             - CLI config - Base URL lives
 #  [*api_version*]          - CLI config - API Version
 #  [*debug*]                - CLI config - Enable/Disable Debug

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -43,7 +43,7 @@ class st2::profile::mongodb (
   if ($::st2::version == 'latest' or
       $::st2::version == 'present' or
       $::st2::version == 'installed' or
-      versioncmp($::st2::version, '2.4.0') >= 0 {
+      versioncmp($::st2::version, '2.4.0') >= 0) {
     $_mongodb_version_default = '3.4'
   }
   else {

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -40,7 +40,10 @@ class st2::profile::mongodb (
 
   # if the StackStorm version is 'latest' or >= 2.4.0 then use MongoDB 3.4
   # else use MongoDB 3.2
-  if $::st2::version == 'latest' or versioncmp($::st2::version, '2.4.0') >= 0 {
+  if ($::st2::version == 'latest' or
+      $::st2::version == 'present' or
+      $::st2::version == 'installed' or
+      versioncmp($::st2::version, '2.4.0') >= 0 {
     $_mongodb_version_default = '3.4'
   }
   else {

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -26,7 +26,10 @@ class st2::profile::nodejs(
 
   # if the StackStorm version is 'latest' or >= 2.4.0 then use NodeJS 6.x
   # else use MongoDB 4.x
-  if $::st2::version == 'latest' or versioncmp($::st2::version, '2.4.0') >= 0 {
+  if ($::st2::version == 'latest' or
+      $::st2::version == 'present' or
+      $::st2::version == 'installed' or
+      versioncmp($::st2::version, '2.4.0') >= 0) {
     $nodejs_version_default = '6.x'
   }
   else {

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -18,13 +18,13 @@
 class st2::profile::python {
   if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '6') {
     package {'python27':
-      ensure => 'latest',
+      ensure => present,
     }
     package {'python27-virtualenv':
-      ensure => 'latest',
+      ensure => present,
     }
     package {'python27-devel':
-      ensure => 'latest',
+      ensure => present,
     }
     exec {'install_pip27':
       path    => '/usr/bin:/usr/sbin:/bin:/sbin',
@@ -35,7 +35,7 @@ class st2::profile::python {
     if !defined(Class['::python']) {
       class { '::python':
         version    => 'system',
-        pip        => latest,
+        pip        => present,
         dev        => true,
         virtualenv => present,
         provider   => 'pip',

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -53,8 +53,8 @@ class st2::profile::server (
   $db_password            = $::st2::db_password,
   $index_url              = $::st2::index_url,
 ) inherits st2 {
-  include '::st2::notices'
-  include '::st2::params'
+  include ::st2::notices
+  include ::st2::params
 
   $_server_packages = $::st2::params::st2_server_packages
   $_conf_dir = $::st2::params::conf_dir
@@ -72,7 +72,7 @@ class st2::profile::server (
   ## Packages
   if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '6') {
     package { 'libffi-devel':
-      ensure => 'latest',
+      ensure => present,
       before => Package[$_server_packages],
     }
   }

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -25,7 +25,7 @@ class st2::profile::web(
   # a dependency cycle is created because we must modify the nginx config
   # in this profile.
   include ::st2::profile::nginx
-  include '::st2::params'
+  include ::st2::params
 
   ## Install the packages
   package { $::st2::params::st2_web_packages:


### PR DESCRIPTION
Previously, by default, this module was configured to auto-updated all of the packages that this module manages.

That means when 2.7 came out, it auto-updated everything in our environment (not good).

This changes the behavior to install the latest version available during initial install (`yum -y install st2`), and subsequent runs just ensure the package is installed. Updates can then be managed out-of-band by organizations at their leisure.