### PR TITLE
Adding st2workflow engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   forward, packages will have `ensure => present` set by default  and it will be
   the responsibility of the end user to update the packages. (Change)
   Contributed by @nmaludy
+- Fixed `st2_pack` type to properly pass the locale settings of the system
+  to the `st2` CLI command. (Bugfix)
+  Contributed by @nmaludy
+- Added support for new `st2workflowengine` (Orchestra) service (Feature)!
+  Contributed by @nmaludy
 
 ## 1.0.0-rc2 (Jan 9, 2018)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,6 +135,11 @@ class st2::params(
     'st2chatops',
   ]
 
+  ## StackStorm Workflow Engine (Orchestra)
+  $st2_workflowengine_services = [
+    'st2workflowengine',
+  ]
+
   ## StackStorm default credentials (change these!)
   $admin_username = 'st2admin'
   $admin_password = 'Ch@ngeMe'


### PR DESCRIPTION
Added service definition for `st2workflowengine` but only if we're installing a version >= 2.8.0