### PR TITLE
Fixing CentOS 7 NodeJS issue

### DIFF
--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -64,8 +64,14 @@ class st2::profile::nodejs(
       File['/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7']
       -> Class['::nodejs']
 
+      File['/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7']
+      -> Package<| tag == 'nodesource_repo' |>
+
       Epel::Rpm_gpg_key['EPEL-7']
       -> Class['::nodejs']
+
+      Epel::Rpm_gpg_key['EPEL-7']
+      -> Package<| tag == 'nodesource_repo' |>
     }
     else {
       # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -50,28 +50,18 @@ class st2::profile::nodejs(
       class { '::nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
-        require             => Class['::epel'],
       }
 
       # TODO remove all of this when we remove support for Puppet 3
-      # the following is required because of Puppet 3's ordering guarnatees
-      Yumrepo['epel']
-      -> Class['::nodejs']
-
-      Yumrepo['epel']
-      -> Package<| tag == 'nodesource_repo' |>
-
-      File['/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7']
-      -> Class['::nodejs']
-
-      File['/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7']
-      -> Package<| tag == 'nodesource_repo' |>
-
-      Epel::Rpm_gpg_key['EPEL-7']
-      -> Class['::nodejs']
-
-      Epel::Rpm_gpg_key['EPEL-7']
-      -> Package<| tag == 'nodesource_repo' |>
+      #   the following is required because of a bug in the verison of
+      #   puppet-nodejs that we're required to use for Puppet 3.
+      #   This bug is fixed in newer versions and only exposes itself
+      #   when `manage_manage_repo` is set to false, like we have here
+      #   for CentOS 7.
+      anchor { '::nodejs::begin': }
+      -> Class['::epel']
+      -> Class['::nodejs::install']
+      -> anchor { '::nodejs::end': }
     }
     else {
       # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -50,8 +50,22 @@ class st2::profile::nodejs(
       class { '::nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
-        require             => Class['::epel'],
+        require             => Class['::epel']
       }
+
+      # TODO remove all of this when we remove support for Puppet 3
+      # the following is required because of Puppet 3's ordering guarnatees
+      Yumrepo['epel']
+      -> Class['::nodejs']
+
+      Yumrepo['epel']
+      -> Package<| tag == 'nodesource_repo' |>
+
+      File['/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7']
+      -> Class['::nodejs']
+
+      Epel::Rpm_gpg_key['EPEL-7']
+      -> Class['::nodejs']
     }
     else {
       # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -50,15 +50,8 @@ class st2::profile::nodejs(
       class { '::nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
+        require             => Class['::epel'],
       }
-      Class['::epel']
-      -> Class['::nodejs']
-
-      Yumrepo['epel']
-      -> Class['::nodejs']
-
-      Yumrepo['epel']
-      -> Package<| tag == 'nodesource_repo' |>
     }
     else {
       # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -50,7 +50,7 @@ class st2::profile::nodejs(
       class { '::nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
-        require             => Class['::epel']
+        require             => Class['::epel'],
       }
 
       # TODO remove all of this when we remove support for Puppet 3

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -50,6 +50,7 @@ class st2::profile::nodejs(
       class { '::nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
+        require             => Class['::epel'],
       }
 
       # TODO remove all of this when we remove support for Puppet 3
@@ -58,10 +59,8 @@ class st2::profile::nodejs(
       #   This bug is fixed in newer versions and only exposes itself
       #   when `manage_manage_repo` is set to false, like we have here
       #   for CentOS 7.
-      anchor { '::nodejs::begin': }
-      -> Class['::epel']
+      Class['::epel']
       -> Class['::nodejs::install']
-      -> anchor { '::nodejs::end': }
     }
     else {
       # Red Hat 6.x requires us to use an OLD version of puppet/nodejs (1.3.0)


### PR DESCRIPTION
Current CentOS 7 build is failing due to GPG key for EPEL not being setup properly prior to NodeJS install.

Not sure WHY this is not working since we have ordering defined correctly. This PR is experimenting to try and fix the problem.