### PR TITLE
Deprecation warning for Puppet 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Added support for new `st2workflowengine` (Orchestra) service (Feature)!
   Contributed by @nmaludy
 
+- Fixed bug where CentOS 7 would sometimes fail to install NodeJS properly.
+  (Bugfix)
+  Contributed by @nmaludy
+
 - DEPRECATION WARNING - Support for Puppet 3 will be dropped in the next
   minor release!
   Contributed by @nmaludy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,22 @@
   GitHub page. The following backends are supported: `flat_file` (default),
   `keystone`, `ldap`, `mongodb`, `pam`. (Feature)
   Contributed by @nmaludy
+  
 - Changed the behavior of `st2` packages. Previously they were automatically 
   updating due to the package resources having `ensure => latest` set. Going
   forward, packages will have `ensure => present` set by default  and it will be
   the responsibility of the end user to update the packages. (Change)
   Contributed by @nmaludy
+  
 - Fixed `st2_pack` type to properly pass the locale settings of the system
   to the `st2` CLI command. (Bugfix)
   Contributed by @nmaludy
+  
 - Added support for new `st2workflowengine` (Orchestra) service (Feature)!
+  Contributed by @nmaludy
+
+- DEPRECATION WARNING - Support for Puppet 3 will be dropped in the next
+  minor release!
   Contributed by @nmaludy
 
 ## 1.0.0-rc2 (Jan 9, 2018)

--- a/README.md
+++ b/README.md
@@ -24,13 +24,11 @@ get you setup and going with minimal effort. Simply:
 include ::st2::profile::fullinstall
 ```
 
-## Deprecation Warning - Puppet 3
+## :warning: Deprecation Warning - Puppet 3
 
-<aside class="warning">
-Puppet 3 was end of life on 12/31/2016. This serves as the official deprecation
+**Puppet 3 was end of life on 12/31/2016. This serves as the official deprecation
 warning notice. The next minor release of this module WILL drop support for
-Puppet 3.
-</aside>
+Puppet 3.**
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Module to manage [StackStorm](http://stackstorm.com)
 
 ## Supported platforms
 
-* Ubuntu 14.04/16.04
-* RHEL/Centos 6/7
+* Ubuntu 14.04
+* Ubuntu 16.04
+* RHEL/CentOS 6
+* RHEL/CentOS 7
 
 ## Quick Start
 
@@ -21,6 +23,14 @@ get you setup and going with minimal effort. Simply:
 ```
 include ::st2::profile::fullinstall
 ```
+
+## Deprecation Warning - Puppet 3
+
+<aside class="warning">
+Puppet 3 was end of life on 12/31/2016. This serves as the official deprecation
+warning notice. The next minor release of this module WILL drop support for
+Puppet 3.
+</aside>
 
 ## Configuration
 


### PR DESCRIPTION
Puppet 3 is EOL. 

This adds a notice for the intention of dropping Puppet 3 support in the next minor release.