### PR TITLE
Fix build for puppet4/5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Development
 
+- Re-ordered dependencies in the Puppetfile for Puppet 4 and Puppet 5.
+  `puppetlabs/stdlib` and `puppetlabs/concat` are now at the bottom in order to
+  let `librarian-puppet` choose the version of these based on other dependencies
+  defined throughout the rest of the file. (Bugfix)
+  Contributed by @nmaludy
+  
 
 ## 1.0.0 (Jul 23, 2018)
 

--- a/build/puppet4/Puppetfile
+++ b/build/puppet4/Puppetfile
@@ -10,8 +10,6 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
-mod 'puppetlabs/concat'
-mod 'puppetlabs/stdlib'
 mod 'jamtur01/httpauth'
 mod 'puppet/staging'
 mod 'maestrodev/wget'
@@ -30,3 +28,5 @@ mod "puppet/selinux"
 mod 'puppet/nginx'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
+mod 'puppetlabs/concat'
+mod 'puppetlabs/stdlib'

--- a/build/puppet5/Puppetfile
+++ b/build/puppet5/Puppetfile
@@ -10,8 +10,6 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
-mod 'puppetlabs/concat'
-mod 'puppetlabs/stdlib'
 mod 'jamtur01/httpauth'
 mod 'puppet/staging'
 mod 'maestrodev/wget'
@@ -30,3 +28,5 @@ mod "puppet/selinux"
 mod 'puppet/nginx'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
+mod 'puppetlabs/concat'
+mod 'puppetlabs/stdlib'


### PR DESCRIPTION
Someone release a new module with different dependencies.

This fixes them by reordering puppetfile for puppet4 + 5
