### PR TITLE
Release for v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Development
 
+
+## 1.1.0 (Sep 07, 2018)
+
 - DEPRECATION WARNING - Dropped support for Puppet 3. (Enhancement)
   Contributed by @nmaludy
   

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,6 @@ clean-bundler:
 	@echo
 	rm -rf build/kitchen/.bundle
 	rm -rf build/kitchen/vendor
+	rm -rf .bundle
+	rm -rf vendor
 	rm -rf /tmp/puppet-st2/build


### PR DESCRIPTION
This is a release commit for v1.1.

Moved all changes from Development into v1.1.0.

Fixed the Makefile script to delete the new directories for the new build procedure (found when creating the release package).

FYI, the version of the module was already bumped to 1.1.0 in `metadata.json` in the PDK PR. 