### PR TITLE
Added st2timersengine service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 - Added support for Puppet 6 on all platforms. (Enhancement)
   Contributed by @nmaludy
 
+- Added support for `st2timersengine` service on StackStorm >= `2.9.0`.
+  Two new options were added to `::st2`:
+    - `timersengine_enabled`  - Set to true if the st2timersengine service should 
+       be enabled on this node (default: true)
+    - `timersengine_timezone` - The local timezone for this node. 
+       (default: 'America/Los_Angeles')
+  #221 (Enhancement)
+  Contributed by @nmaludy
+  
+- Changed integration tests to test for HTTP `308` redirect on Ubuntu 
+  when redirecting from http:// to https:// (Enhancement)
+  Contributed by @nmaludy
+
 ## 1.1.0 (Sep 07, 2018)
 
 - DEPRECATION WARNING - Dropped support for Puppet 3. (Enhancement)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,9 @@
 #                             (default: true)
 #  [*nginx_manage_repo*]    - Set this to false when you have your own repositories for nginx
 #                             (default: true)
+#  [*timersengine_enabled*]  - Set to true if the st2timersengine service should be enabled
+#                              on this node (default: true)
+#  [*timersengine_timezone*] - The local timezone for this node. (default: 'America/Los_Angeles')
 #  [*chatops_adapter*]      - Adapter package(s) to be installed with npm. List of hashes.
 #  [*chatops_adapter_conf*] - Configuration parameters for Hubot adapter (hash)
 #  [*chatops_hubot_log_level*]              - Logging level for hubot (string)
@@ -169,6 +172,8 @@ class st2(
   $datastore_keys_dir       = $::st2::params::datstore_keys_dir,
   $datastore_key_path       = "${::st2::params::datstore_keys_dir}/datastore_key.json",
   $nginx_manage_repo        = true,
+  $timersengine_enabled     = $::st2::params::st2timersengine_enabled,
+  $timersengine_timezone    = $::st2::params::st2timersengine_timezone,
   $chatops_adapter          = $::st2::params::chatops_adapter,
   $chatops_adapter_conf     = $::st2::params::chatops_adapter_conf,
   $chatops_hubot_log_level              = $::st2::params::hubot_log_level,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,9 +136,16 @@ class st2::params(
   ]
 
   ## StackStorm Workflow Engine (Orchestra)
-  $st2_workflowengine_services = [
+  $st2workflowengine_services = [
     'st2workflowengine',
   ]
+
+  ## StackStorm Timers Engine
+  $st2timersengine_services = [
+    'st2timersengine',
+  ]
+  $st2timersengine_enabled = true
+  $st2timersengine_timezone = 'America/Los_Angeles'
 
   ## StackStorm default credentials (change these!)
   $admin_username = 'st2admin'

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -69,17 +69,27 @@ class st2::profile::server (
   }
 
   # Workflow Engine was introduced in 2.8.0
+  # Timers Engine was introduced in 2.9.0
   if ($::st2::version == 'latest' or
       $::st2::version == 'present' or
       $::st2::version == 'installed' or
-      versioncmp($::st2::version, '2.8.0') >= 0) {
+      versioncmp($::st2::version, '2.9.0') >= 0) {
     $_st2_services = concat($::st2::params::st2_services,
-                            $::st2::params::st2_workflowengine_services)
+                            $::st2::params::st2workflowengine_services,
+                            $::st2::params::st2timersengine_services)
     $_has_workflowengine = true
+    $_has_timersengine = true
+  }
+  elsif versioncmp($::st2::version, '2.8.0') >= 0) {
+    $_st2_services = concat($::st2::params::st2_services,
+                            $::st2::params::st2workflowengine_services)
+    $_has_workflowengine = true
+    $_has_timersengine = false
   }
   else {
     $_st2_services = $::st2::params::st2_services
     $_has_workflowengine = false
+    $_has_timersengine = false
   }
 
   ########################################
@@ -273,6 +283,36 @@ class st2::profile::server (
       section => 'workflow_engine',
       setting => 'logging',
       value   => "/etc/st2/${_logger_config}.workflowengine.conf",
+      tag     => 'st2::config',
+    }
+  }
+
+  ## Timers Engine settings
+  if $_has_timersengine {
+    ini_setting { 'timersengine_logging':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'timersengine',
+      setting => 'logging',
+      value   => "/etc/st2/${_logger_config}.timersengine.conf",
+      tag     => 'st2::config',
+    }
+
+    ini_setting { 'timersengine_enabled':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'timersengine',
+      setting => 'enabled',
+      value   => $::st2::timersengine_enabled,
+      tag     => 'st2::config',
+    }
+
+    ini_setting { 'timersengine_local_timezone':
+      ensure  => present,
+      path    => '/etc/st2/st2.conf',
+      section => 'timersengine',
+      setting => 'local_timezone',
+      value   => $::st2::timersengine_timezone,
       tag     => 'st2::config',
     }
   }

--- a/test/integration/stackstorm/controls/services_test.rb
+++ b/test/integration/stackstorm/controls/services_test.rb
@@ -8,7 +8,7 @@
 ST2_SERVICES = ['st2actionrunner', 'st2api', 'st2stream',
                 'st2auth', 'st2garbagecollector', 'st2notifier',
                 'st2resultstracker', 'st2rulesengine', 'st2sensorcontainer',
-                'st2workflowengine'].freeze
+                'st2workflowengine', 'st2timersengine'].freeze
 
 control 'st2-services' do
   title 'verify stackstorm services'

--- a/test/integration/stackstorm/controls/st2web_test.rb
+++ b/test/integration/stackstorm/controls/st2web_test.rb
@@ -85,11 +85,12 @@ control 'st2web' do
   end
 
   if os.debian?
+    # on Debian/Ubuntu nginx redirects by returning a 308
     describe http('http://localhost/', enable_remote_worker: true) do
-      its('status') { should eq 301 }
+      its('status') { should eq 308 }
     end
   elsif os.redhat?
-    # on RHEL nginx redirects to https and returns 200
+    # on RHEL nginx automatically redirects to https and returns 200
     describe http('http://localhost/', enable_remote_worker: true) do
       its('status') { should eq 200 }
     end


### PR DESCRIPTION
Closes #221 

* Adds support for new `st2timersengine` service in `2.9.0`
* Fixes the redirect InSpec tests for Debian to look for HTTP 308 instead of 301