### PR TITLE
Fix Puppet 4 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system
+  # need to comment out the system update because this upgrades rubygem-update
+  # further than what's allowable for Puppet 4. rubygem-update 3.0.0 requires
+  # ruby 2.3.0 and Puppet 4 requires ruby 2.1.0
+  #- gem update --system
   - gem --version
   - bundle -v
 bundler_args: --without system_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Development
 
+- Fixed build for Puppet 4. New version of rubygem-update requires Ruby 2.3.0
+  and Puppet 4 requires 2.1.x. When running `gem update --system` this updated
+  the gem past the installed ruby version, breaking the build. Instead,
+  we simply leave the system gems alone during the build.
+  Contributed by @nmaludy
 
 ## 1.3.0 (Dec 17, 2018)
 

--- a/build/centos7-puppet4/Dockerfile
+++ b/build/centos7-puppet4/Dockerfile
@@ -36,7 +36,10 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
   BUNDLE_PATH=/bundle
 RUN /bin/bash -l -c "bundle -v"
 RUN /bin/bash -l -c "rm -f ${APP_HOME}/Gemfile.lock"
-RUN /bin/bash -l -c "gem update --system"
+# need to comment out the system update because this upgrades rubygem-update
+# further than what's allowable for Puppet 4. rubygem-update 3.0.0 requires
+# ruby 2.3.0 and Puppet 4 requires ruby 2.1.0
+# RUN /bin/bash -l -c "gem update --system"
 RUN /bin/bash -l -c "gem --version"
 RUN /bin/bash -l -c "bundle -v"
 RUN cat $BUNDLE_GEMFILE


### PR DESCRIPTION
Fixed build for Puppet 4. New version of rubygem-update requires Ruby 2.3.0 and Puppet 4 requires 2.1.x. When running `gem update --system` this updated the gem past the installed ruby version, breaking the build. Instead, we simply leave the system gems alone during the build.