### PR TITLE
Deprecated Puppet 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Puppet 4 is officially deprecated due to it being End of Life on 2018-12-31.
+  Support will be removed in a future version. (Enhancement)
+  Contributed by @nmaludy
+
 - Fixed build for Puppet 4. New version of rubygem-update requires Ruby 2.3.0
   and Puppet 4 requires 2.1.x. When running `gem update --system` this updated
   the gem past the installed ruby version, breaking the build. Instead,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ puppet module install stackstorm-st2
 puppet apply -e "include ::st2::profile::fullinstall"
 ```
 
+## :warning: Deprecation Notice - Puppet 4
+
+Puppet 4 reached End of Life on 2018-12-31. As of version `1.4` use of Puppet 4 with this module
+is officially deprecated. The next minor release of the module will drop support
+for Puppet 4 in the CI testing matrix. The next major release of the module will drop
+support for Puppet 4 by adjusting the minimum supported Puppet version in `metadata.json`.
+
 ## :warning: Deprecation Notice - Puppet 3
 
 **This module no longer supports Puppet 3 as of version `1.1`**


### PR DESCRIPTION
Simple documentation change for now.

The next minor release we'll adjust the Travis text matrix.

The next major release we'll raise the minimum Puppet version in `metadata.json`.