### PR TITLE
Fixing build caused by new puppet/nginx release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Development
 
+- Fixed build for new release of `puppet/nginx` causing conflict with `puppetlabs/stdlib`.
+  The new version `0.16.0` of `puppet/nginx` requires `puppetlabs/stdlib >= 5.0.0`.
+  Several other modules we depend on require `puppetlabs/stdlib < 5.0.05` causing a conflict.
+  To fix this, we've pinned `puppet/nginx` to `0.15.0` in the Puppetfiles used
+  for testing. (Bugfix)
+  Contributed by @nmaludy
+
 - Fixed build for Puppet 4. New version of rubygem-update requires Ruby 2.3.0
   and Puppet 4 requires 2.1.x. When running `gem update --system` this updated
   the gem past the installed ruby version, breaking the build. Instead,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 - Fixed build for new release of `puppet/nginx` causing conflict with `puppetlabs/stdlib`.
   The new version `0.16.0` of `puppet/nginx` requires `puppetlabs/stdlib >= 5.0.0`.
-  Several other modules we depend on require `puppetlabs/stdlib < 5.0.05` causing a conflict.
+  Several other modules we depend on require `puppetlabs/stdlib < 5.0.0` causing a conflict.
   To fix this, we've pinned `puppet/nginx` to `0.15.0` in the Puppetfiles used
   for testing. (Bugfix)
+  Contributed by @nmaludy
+  
+- Removed the dependencies because they're no longer used.
+    - `puppet/staging`
+    - `puppetlabs/gcc`
+  (Enhancement)
   Contributed by @nmaludy
 
 - Puppet 4 is officially deprecated due to it being End of Life on 2018-12-31.

--- a/build/centos6-puppet4/Puppetfile
+++ b/build/centos6-puppet4/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/centos6-puppet5/Puppetfile
+++ b/build/centos6-puppet5/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/centos6-puppet6/Puppetfile
+++ b/build/centos6-puppet6/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/centos7-puppet4/Puppetfile
+++ b/build/centos7-puppet4/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/centos7-puppet5/Puppetfile
+++ b/build/centos7-puppet5/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu14-puppet4/Puppetfile
+++ b/build/ubuntu14-puppet4/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu14-puppet5/Puppetfile
+++ b/build/ubuntu14-puppet5/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu14-puppet6/Puppetfile
+++ b/build/ubuntu14-puppet6/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu16-puppet4/Puppetfile
+++ b/build/ubuntu16-puppet4/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu16-puppet5/Puppetfile
+++ b/build/ubuntu16-puppet5/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/build/ubuntu16-puppet6/Puppetfile
+++ b/build/ubuntu16-puppet6/Puppetfile
@@ -11,20 +11,19 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppet/rabbitmq'
 mod 'jamtur01/httpauth'
-mod 'puppet/staging'
 mod 'puppet/wget'
 mod 'saz/sudo'
 mod 'puppet/python'
-mod 'puppetlabs/gcc'
 mod 'puppetlabs/inifile'
 mod 'puppet/mongodb'
 mod 'puppetlabs/postgresql'
 mod 'stahnma/epel'
 mod 'ghoneycutt/facter'
 mod 'computology/packagecloud'
-mod "puppet/selinux"
-mod 'puppet/nginx'
+mod 'puppet/selinux'
+# hard coding 0.15.0 because it requires stdlib >= 5.0.0
+# several other dependencies require stdlib < 5.0.0 causing a conflict
+mod 'puppet/nginx', '0.15.0'
 mod 'puppet/nodejs'
 mod 'puppetlabs/apt'
-mod 'puppetlabs/concat'
 mod 'puppetlabs/stdlib'

--- a/metadata.json
+++ b/metadata.json
@@ -17,10 +17,6 @@
       "version_requirement": ">= 4.6.0"
     },
     {
-      "name": "puppet/staging",
-      "version_requirement": ">= 1.0.2"
-    },
-    {
       "name": "puppetlabs/apt",
       "version_requirement": ">= 1.7.0"
     },
@@ -35,10 +31,6 @@
     {
       "name": "puppet/python",
       "version_requirement": ">= 1.10.0"
-    },
-    {
-      "name": "puppetlabs/gcc",
-      "version_requirement": ">= 0.2.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
Fixed build for new release of `puppet/nginx` causing conflict with `puppetlabs/stdlib`.
The new version `0.16.0` of `puppet/nginx` requires `puppetlabs/stdlib >= 5.0.0`.
Several other modules we depend on require `puppetlabs/stdlib < 5.0.0` causing a conflict.
To fix this, we've pinned `puppet/nginx` to `0.15.0` in the Puppetfiles used
for testing.