### PR TITLE
Fixed bug where auth failure reason was not logged to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Development
 
+- Fixed a bug in the `st2_pack` resource so that when authentication fails, the error
+  message about why it failed is shown to the user. Along with this i prevented the
+  authentication command from being written to the debug log to prevent potential
+  credential leakage.
+  (Bugfix)
+  Contributed by @nmaludy
+
 ## 1.4.0 (Feb 13, 2019)
 
 - Added new tasks to communicate with the StackStorm CLI. The naming standard and parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 ## Development
 
 - Fixed a bug in the `st2_pack` resource so that when authentication fails, the error
-  message about why it failed is shown to the user. Along with this i prevented the
-  authentication command from being written to the debug log to prevent potential
-  credential leakage.
+  message about why it failed is shown to the user.
   (Bugfix)
   Contributed by @nmaludy
+  
+- Fixed a bug in the `st2_pack` resource where usernames and passwords were not being
+  escaped properly. This only manifested itself with certain special characters.
+  (Bugfix)
+  Contributed by @nmaludy
+  
 
 ## 1.4.0 (Feb 13, 2019)
 

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -25,8 +25,7 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
     it 'authenticates and receives a token' do
       expect(provider).to receive(:exec_st2).with('auth', 'st2_user',
                                                   '-t',
-                                                  '-p', 'st2_password',
-                                                  sensitive: true)
+                                                  '-p', 'st2_password')
                                             .and_return("token\n")
       expect(provider.st2_authenticate).to eq('token')
     end

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -121,7 +121,9 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
     it 'escapes arguments' do
       expect(Puppet::Util::Execution).to receive(:execute)
         .with('/usr/bin/st2 pack search arg\ with\ spaces \"\ blah\" \)\( \#',
-              override_locale: false)
+              override_locale: false,
+              failonfail: true,
+              combine: true)
       provider.send(:exec_st2,
                     'pack', 'search',
                     'arg with spaces',

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -25,7 +25,8 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
     it 'authenticates and receives a token' do
       expect(provider).to receive(:exec_st2).with('auth', 'st2_user',
                                                   '-t',
-                                                  '-p', 'st2_password')
+                                                  '-p', 'st2_password',
+                                                  sensitive: true)
                                             .and_return("token\n")
       expect(provider.st2_authenticate).to eq('token')
     end
@@ -114,7 +115,10 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
         .with(['/usr/bin/st2', 'auth', 'someuser',
                '-t',
                '-p', 'blah'],
-              override_locale: false)
+              override_locale: false,
+              failonfail: true,
+              combine: true,
+              sensitive: false)
       provider.send(:exec_st2, 'auth', 'someuser', '-t', '-p', 'blah')
     end
 
@@ -132,6 +136,19 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
                     '" blah"',
                     ')(',
                     '#')
+    end
+
+    it 'executes a propagates sensitive option' do
+      expect(Puppet::Util::Execution).to receive(:execute)
+        .with(['/usr/bin/st2', 'auth', 'someuser',
+               '-t',
+               '-p', 'blah'],
+              override_locale: false,
+              failonfail: true,
+              combine: true,
+              sensitive: true)
+      provider.send(:exec_st2, 'auth', 'someuser', '-t', '-p', 'blah',
+                    sensitive: true)
     end
   end
 end

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -112,23 +112,16 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
   describe 'exec_st2' do
     it 'executes a command' do
       expect(Puppet::Util::Execution).to receive(:execute)
-        .with(['/usr/bin/st2', 'auth', 'someuser',
-               '-t',
-               '-p', 'blah'],
+        .with('/usr/bin/st2 auth someuser -t -p blah',
               override_locale: false,
               failonfail: true,
-              combine: true,
-              sensitive: false)
+              combine: true)
       provider.send(:exec_st2, 'auth', 'someuser', '-t', '-p', 'blah')
     end
 
     it 'escapes arguments' do
       expect(Puppet::Util::Execution).to receive(:execute)
-        .with(['/usr/bin/st2', 'pack', 'search',
-               'arg\ with\ spaces',
-               '\"\ blah\"',
-               '\)\(',
-               '\#'],
+        .with('/usr/bin/st2 pack search arg\ with\ spaces \"\ blah\" \)\( \#',
               override_locale: false)
       provider.send(:exec_st2,
                     'pack', 'search',
@@ -136,19 +129,6 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
                     '" blah"',
                     ')(',
                     '#')
-    end
-
-    it 'executes a propagates sensitive option' do
-      expect(Puppet::Util::Execution).to receive(:execute)
-        .with(['/usr/bin/st2', 'auth', 'someuser',
-               '-t',
-               '-p', 'blah'],
-              override_locale: false,
-              failonfail: true,
-              combine: true,
-              sensitive: true)
-      provider.send(:exec_st2, 'auth', 'someuser', '-t', '-p', 'blah',
-                    sensitive: true)
     end
   end
 end

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -70,6 +70,7 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
 
   describe 'exists?' do
     it 'checks if pack exists' do
+      expect(provider).to receive(:list_installed_packs).and_return([])
       expect(provider.exists?).to be false
     end
 


### PR DESCRIPTION
Previously when the `st2_pack` resource was trying to run and invalid credentials were passed, then the `st2 auth` command would silently fail, then a bad "token" string would be passed to the `st2 pack install` command resulting in odd errors.

This PR fixes this issue by passing in all necessary options in order to actually fail the command if the `exit status != 0`.