### PR TITLE
Use column "ref" when checking already installed packs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   (Enhancement)
   Contributed by @nmaludy
 
+- Already installed packs are now recognized by their configured "ref" variable instead of "name"
+  (Enhancement)
+  Contributed by @ruriky
+
 ## 1.4.0 (Feb 13, 2019)
 
 - Added new tasks to communicate with the StackStorm CLI. The naming standard and parameters

--- a/lib/puppet/provider/st2_pack/default.rb
+++ b/lib/puppet/provider/st2_pack/default.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:st2_pack).provide(:default) do
 
   def list_installed_packs
     token = st2_authenticate
-    output = exec_st2('pack', 'list', '-a', 'name', '-j', '-t', token)
+    output = exec_st2('pack', 'list', '-a', 'ref', '-j', '-t', token)
     parse_output_json(output)
   end
 
@@ -39,7 +39,7 @@ Puppet::Type.type(:st2_pack).provide(:default) do
     result = []
     if raw && !raw.empty?
       pack_list = JSON.parse(raw)
-      result = pack_list.map { |pack| pack['name'] }
+      result = pack_list.map { |pack| pack['ref'] }
       debug("Installed packs: #{result}")
     end
     result

--- a/spec/unit/puppet/provider/st2_pack/default_spec.rb
+++ b/spec/unit/puppet/provider/st2_pack/default_spec.rb
@@ -87,10 +87,10 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
                                                   '-p', 'st2_password')
                                             .and_return('token')
       expect(provider).to receive(:exec_st2).with('pack', 'list',
-                                                  '-a', 'name',
+                                                  '-a', 'ref',
                                                   '-j',
                                                   '-t', 'token')
-                                            .and_return('[{"name": "pack1"}, {"name": "pack2"}]')
+                                            .and_return('[{"ref": "pack1"}, {"ref": "pack2"}]')
       expect(provider.list_installed_packs).to eq ['pack1', 'pack2']
     end
   end
@@ -105,7 +105,7 @@ describe Puppet::Type.type(:st2_pack).provider(:default) do
     end
 
     it 'extracts pack names from a JSON string' do
-      expect(provider.parse_output_json('[{"name": "core"}, {"name": "examples"}]')).to eq ['core', 'examples']
+      expect(provider.parse_output_json('[{"ref": "core"}, {"ref": "examples"}]')).to eq ['core', 'examples']
     end
   end
 


### PR DESCRIPTION
We use "st2 pack list" command to list currently installed packages. We
should compare the configured pack names with names in the column "ref", not with the names in the
column "name".

![st2_pack_list](https://user-images.githubusercontent.com/19946546/58015253-10dfe780-7afb-11e9-8674-4379d5a680e6.PNG)
