### PR TITLE
1.5.0 release. Fixed bug in Mistral connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Development
 
+
+## 1.5.0 (Oct 2, 2019)
+
+- Fixed a bug in the `mistral` Postrgres connection string where passwords weren't
+  being URL encoded / escaped. This could lead to potentially bad URL parsing
+  when passwords contained certain special characters. To fix this, the 
+  password in the mistral `connection` parameter is now URL encoded / escaped.
+  (Bugfix)
+  Contributed by @nmaludy
+
 - Fixed a bug in the `st2_pack` resource so that when authentication fails, the error
   message about why it failed is shown to the user.
   (Bugfix)

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -72,12 +72,15 @@ class st2::profile::mistral(
   ### End Mistral Packages ###
 
   ### Mistral Config ###
+  # URL encode the password, in case it contains special characters that
+  # can mess up the URL in the config.
+  $_db_password = st2::urlencode($db_password)
   ini_setting { 'database_connection':
     ensure  => present,
     path    => $mistral_config,
     section => 'database',
     setting => 'connection',
-    value   => "postgresql://${db_username}:${db_password}@${db_host}/${db_name}",
+    value   => "postgresql://${db_username}:${_db_password}@${db_host}/${db_name}",
     tag     => 'mistral',
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "stackstorm-st2",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "stackstorm",
   "summary": "Puppet module to manage/configure StackStorm",
   "license": "Apache-2.0",


### PR DESCRIPTION
Two things:

1. 1.5.0 release (about time)
2. Fixed a bug in the Mistral connection string parameter. Previously we were just writing the user-inputted password. This would have been fine except that the Mistral connection is a URL, so if passwords contained special characters, then the URL could be invalid. Simple URL escape on the password and we're all good.