### PR TITLE
Updated puppet-lint-absolute_classname-check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
+  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -88,6 +89,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/.sync.yml
+++ b/.sync.yml
@@ -26,7 +26,8 @@ Gemfile:
   required:
     ':development':
       - gem: 'puppet-lint-absolute_classname-check'
-        version: '>= 0.2.4'
+        # pin to 2.0.0 to comply with new standard which removes the leading ::
+        version: '>= 2.0.0'
       - gem: 'puppet-lint-absolute_template_path'
         version: '>= 1.0.1'
       - gem: 'puppet-lint-alias-check'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Updated to new Puppet style guide where the leading `::` in class names is no longer
+  acceptable. (Bugfix)
+  Contributed by @nmaludy
+
 
 ## 1.5.0 (Oct 2, 2019)
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',                   require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',                 require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',                     require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-lint-absolute_classname-check", '>= 0.2.4',                      require: false
+  gem "puppet-lint-absolute_classname-check", '>= 2.0.0',                      require: false
   gem "puppet-lint-absolute_template_path", '>= 1.0.1',                        require: false
   gem "puppet-lint-alias-check", '>= 0.1.1',                                   require: false
   gem "puppet-lint-classes_and_types_beginning_with_digits-check", '>= 0.1.2', require: false

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ get you setup and going with minimal effort. Simply:
 
 ```
 puppet module install stackstorm-st2
-puppet apply -e "include ::st2::profile::fullinstall"
+puppet apply -e "include st2::profile::fullinstall"
 ```
 
 ## :warning: Deprecation Notice - Puppet 4
@@ -216,7 +216,7 @@ Configuration via Hiera:
   # Public URL used by ChatOps to offer links to execution details via the WebUI.
   st2::chatops_web_url: '"stackstorm.domain.tld"'
   
-  # install and configure hubot adapter (rocketchat, nodejs module installed by ::nodejs)
+  # install and configure hubot adapter (rocketchat, nodejs module installed by nodejs)
   st2::chatops_adapter:
     hubot-adapter:
       package: 'hubot-rocketchat'

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ By default the `flat_file` backend is used. To change this you can configure it
 when instantiating the `::st2` class in a manifest file:
 
 ``` ruby
-class { '::st2':
+class { 'st2':
   auth_backend => 'ldap',
 }
 ```
@@ -166,7 +166,7 @@ using the `auth_backend_config` option. This option can be changed when instanti
 the `::st2` class in a manifest file:
 
 ``` ruby
-class { '::st2':
+class { 'st2':
   auth_backend        => 'ldap',
   auth_backend_config => {
     ldap_uri      => 'ldaps://ldap.domain.tld',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -69,7 +69,7 @@ Base class for st2 module. Used as top-level to set parameters via Hiera, this c
 ##### Basic Usage
 
 ```puppet
-include ::st2
+include st2
 ```
 
 ##### Variables can be set in Hiera and take advantage of automatic data bindings:
@@ -776,7 +776,7 @@ The auth backend implementations are in the manifests/auth/ directory.
 
 #### Examples
 
-##### Basic usage (via ::st2)
+##### Basic usage (via st2)
 
 ```puppet
 class { '::st2':
@@ -798,7 +798,7 @@ st2::auth_backend_config"
 ##### Direct usage (default Flat File auth backend)
 
 ```puppet
-include ::st2::auth
+include st2::auth
 ```
 
 ##### Direct usage to configure a specific auth backend
@@ -955,7 +955,7 @@ Auth class to configure and setup Flat File (htpasswd) Authentication
 
 #### Examples
 
-##### Instantiate via ::st2
+##### Instantiate via st2
 
 ```puppet
 class { '::st2':
@@ -1017,7 +1017,7 @@ For information on parameters see the
 
 #### Examples
 
-##### Instantiate via ::st2
+##### Instantiate via st2
 
 ```puppet
 class { '::st2':
@@ -1073,7 +1073,7 @@ For information on parameters see the
 
 #### Examples
 
-##### Instantiate via ::st2 (Active Directory)
+##### Instantiate via st2 (Active Directory)
 
 ```puppet
 class { '::st2':
@@ -1206,7 +1206,7 @@ For information on parameters see the
 
 #### Examples
 
-##### Instantiate via ::st2
+##### Instantiate via st2
 
 ```puppet
 class { '::st2':
@@ -1300,7 +1300,7 @@ You will need to auth a non-root user on the Linux host.
 
 #### Examples
 
-##### Instantiate via ::st2
+##### Instantiate via st2
 
 ```puppet
 class { '::st2':
@@ -1357,7 +1357,7 @@ places.
 ##### Basic usage
 
 ```puppet
-include ::st2::logging::rsyslog
+include st2::logging::rsyslog
 ```
 
 ### st2::notices
@@ -1425,7 +1425,7 @@ class { '::st2::params':
   admin_username => 'myuser',
   admin_password => 'SuperSecret!',
 }
-include ::st2::profile::fullinstall
+include st2::profile::fullinstall
 ```
 
 #### Parameters
@@ -1445,7 +1445,7 @@ Default value: 'st2packs'
 Data type: `Any`
 
 Hostname of the StackStorm box. This is used as the default to drive a lot of
-other parameters in the ::st2 class such as auth URL, MongoDB host, RabbitMQ host, etc.
+other parameters in the st2 class such as auth URL, MongoDB host, RabbitMQ host, etc.
 
 Default value: '127.0.0.1'
 
@@ -1762,18 +1762,18 @@ Components:
 ##### Basic Usage
 
 ```puppet
-include ::st2::profile::fullinstall
+include st2::profile::fullinstall
 ```
 
 ##### Customizing parameters
 
 ```puppet
-# Customizations are done via the main ::st2 class
+# Customizations are done via the main st2 class
 class { '::st2':
   # ... assign custom parameters
 }
 
-include ::st2::profile::fullinstall
+include st2::profile::fullinstall
 ```
 
 ### st2::profile::mistral
@@ -1785,7 +1785,7 @@ This class installs OpenStack Mistral, a workflow engine that integrates with St
 ##### Basic Usage
 
 ```puppet
-include ::st2::profile::mistral
+include st2::profile::mistral
 ```
 
 ##### External database
@@ -1901,10 +1901,10 @@ StackStorm compatable installation of MongoDB and dependencies.
 ##### Basic Usage
 
 ```puppet
-include ::st2::profile::mongodb
+include st2::profile::mongodb
 ```
 
-##### Customize (done via ::st2)
+##### Customize (done via st2)
 
 ```puppet
 class { '::st2':
@@ -1913,7 +1913,7 @@ class { '::st2':
   db_password => 'xyz123',
   db_port     => 12345,
 }
-include ::st2::profile::mongodb
+include st2::profile::mongodb
 ```
 
 #### Parameters
@@ -2059,7 +2059,7 @@ st2 compatable installation of PostgreSQL and dependencies for use with StackSto
 ##### Basic usage
 
 ```puppet
-include ::st2::profile::postgresql
+include st2::profile::postgresql
 ```
 
 ##### Customizing parameters
@@ -2106,7 +2106,7 @@ StackStorm compatable installation of RabbitMQ and dependencies.
 include st2::profile::rabbitmq
 ```
 
-##### Authentication enabled (configured vi ::st2)
+##### Authentication enabled (configured vi st2)
 
 ```puppet
 class { '::st2':
@@ -2169,7 +2169,7 @@ Manages the installation of st2 required repos for installing the StackStorm pac
 ##### Basic usage
 
 ```puppet
-include ::st2::profile::repos
+include st2::profile::repos
 ```
 
 ##### Installing from unstable
@@ -2429,7 +2429,7 @@ Profile to install, configure and manage StackStorm web UI (st2web).
 ##### Basic Usage
 
 ```puppet
-include ::st2::profile::web'
+include st2::profile::web'
 ```
 
 #### Parameters
@@ -2486,7 +2486,7 @@ https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample#L251-L259
 ##### Basic usage
 
 ```puppet
-include ::st2::scheduler
+include st2::scheduler
 ```
 
 ##### Customizing parameters
@@ -2535,7 +2535,7 @@ Generates and manages crypto keys for use with the StackStorm datastore
 ##### Basic Usage
 
 ```puppet
-include ::st2::server::datastore_keys
+include st2::server::datastore_keys
 ```
 
 ##### Custom key path
@@ -2586,7 +2586,7 @@ Installs the default admin user for st2 (stanley).
 ##### Basic Usage
 
 ```puppet
-include ::st2::stanley
+include st2::stanley
 ```
 
 ##### Custom SSH keys
@@ -2666,7 +2666,7 @@ https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample#L337-L343
 ##### Basic usage
 
 ```puppet
-include ::st2::timersengine
+include st2::timersengine
 ```
 
 ##### Customizing parameters
@@ -2713,7 +2713,7 @@ https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample
 ##### Basic usage
 
 ```puppet
-include ::st2::workflowengine
+include st2::workflowengine
 ```
 
 ## Defined types

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,12 +82,12 @@ st2::version: 2.10.1
 
 ```puppet
 # best practice is to change default username/password
-class { '::st2::params':
+class { 'st2::params':
   admin_username => 'st2admin',
   admin_password => 'SuperSecret!',
 }
 
-class { '::st2':
+class { 'st2':
   version => '2.10.1',
 }
 ```
@@ -95,7 +95,7 @@ class { '::st2':
 ##### Different passwords for each database (MongoDB, RabbitMQ, Postgres)
 
 ```puppet
-class { '::st2':
+class { 'st2':
   # StackStorm user
   cli_username        => 'st2admin',
   cli_password        => 'SuperSecret!',
@@ -779,7 +779,7 @@ The auth backend implementations are in the manifests/auth/ directory.
 ##### Basic usage (via st2)
 
 ```puppet
-class { '::st2':
+class { 'st2':
   auth_backend        => 'flat_file',
   auth_backend_config => {
     htpasswd_file => '/etc/something/htpasswd',
@@ -958,7 +958,7 @@ Auth class to configure and setup Flat File (htpasswd) Authentication
 ##### Instantiate via st2
 
 ```puppet
-class { '::st2':
+class { 'st2':
   auth_backend        => 'flat_file',
   auth_backend_config => {
     htpasswd_file => '/etc/something/htpasswd',
@@ -1020,7 +1020,7 @@ For information on parameters see the
 ##### Instantiate via st2
 
 ```puppet
-class { '::st2':
+class { 'st2':
   auth_backend        => 'keystone',
   auth_backend_config => {
     keystone_url     => 'http://keystone.domain.tld:5000',
@@ -1076,7 +1076,7 @@ For information on parameters see the
 ##### Instantiate via st2 (Active Directory)
 
 ```puppet
-class { '::st2':
+class { 'st2':
   auth_backend        => 'ldap',
   auth_backend_config => {
     ldap_uri      => 'ldaps://ldap.domain.tld',
@@ -1209,7 +1209,7 @@ For information on parameters see the
 ##### Instantiate via st2
 
 ```puppet
-class { '::st2':
+class { 'st2':
   auth_backend        => 'mongodb',
   auth_backend_config => {
     db_host => 'mongodb.stackstorm.net',
@@ -1303,7 +1303,7 @@ You will need to auth a non-root user on the Linux host.
 ##### Instantiate via st2
 
 ```puppet
-class { '::st2':
+class { 'st2':
   backend => 'pam',
 }
 ```
@@ -1379,7 +1379,7 @@ and st2::pack::config for usage
 ##### Basic Usage
 
 ```puppet
-class { '::st2::packs':
+class { 'st2::packs':
   packs => {
     puppet => {},
     influxdb => {
@@ -1421,7 +1421,7 @@ Main parameters to manage the st2 module
 ##### Best Practice
 
 ```puppet
-class { '::st2::params':
+class { 'st2::params':
   admin_username => 'myuser',
   admin_password => 'SuperSecret!',
 }
@@ -1477,7 +1477,7 @@ it through the main +::st2+ class
 ##### Basic Usage
 
 ```puppet
-class { '::st2':
+class { 'st2':
   chatops_hubot_name => '"@RosieRobot"',
   chatops_api_key    => '"xxxxyyyyy123abc"',
   chatops_adapter    => {
@@ -1769,7 +1769,7 @@ include st2::profile::fullinstall
 
 ```puppet
 # Customizations are done via the main st2 class
-class { '::st2':
+class { 'st2':
   # ... assign custom parameters
 }
 
@@ -1791,7 +1791,7 @@ include st2::profile::mistral
 ##### External database
 
 ```puppet
-class { '::st2::profile::mistral':
+class { 'st2::profile::mistral':
   db_host     => 'postgres.domain.tld',
   db_username => 'mistral',
   db_password => 'xyz123',
@@ -1801,7 +1801,7 @@ class { '::st2::profile::mistral':
 ##### External RabbitMQ
 
 ```puppet
-class { '::st2::profile::mistral':
+class { 'st2::profile::mistral':
   rabbitmq_hostname => 'rabbitmq.domain.tld',
   rabbitmq_username => 'mistral',
   rabbitmq_password => 'xyz123',
@@ -1907,7 +1907,7 @@ include st2::profile::mongodb
 ##### Customize (done via st2)
 
 ```puppet
-class { '::st2':
+class { 'st2':
   db_name     => 'stackstormdb',
   db_username => 'abc',
   db_password => 'xyz123',
@@ -2065,7 +2065,7 @@ include st2::profile::postgresql
 ##### Customizing parameters
 
 ```puppet
-class { '::st2::profile::postgresql':
+class { 'st2::profile::postgresql':
   db_bind_ips => '0.0.0.0',
 }
 ```
@@ -2109,7 +2109,7 @@ include st2::profile::rabbitmq
 ##### Authentication enabled (configured vi st2)
 
 ```puppet
-class { '::st2':
+class { 'st2':
   rabbitmq_username => 'rabbitst2',
   rabbitmq_password => 'secret123',
 }
@@ -2175,7 +2175,7 @@ include st2::profile::repos
 ##### Installing from unstable
 
 ```puppet
-class { '::st2::profile::repos':
+class { 'st2::profile::repos':
   repository => 'unstable',
 }
 ```
@@ -2492,7 +2492,7 @@ include st2::scheduler
 ##### Customizing parameters
 
 ```puppet
-class { '::st2::scheduler':
+class { 'st2::scheduler':
   sleep_interval => 60,
   gc_interval    => 120,
 }
@@ -2541,7 +2541,7 @@ include st2::server::datastore_keys
 ##### Custom key path
 
 ```puppet
-class { '::st2::server::datastore_keys':
+class { 'st2::server::datastore_keys':
   keys_dir => '/path/to/custom/keys',
   key_path => '/path/to/custom/keys/datastore_key.json.',
 }
@@ -2592,7 +2592,7 @@ include st2::stanley
 ##### Custom SSH keys
 
 ```puppet
-class { '::st2::stanley':
+class { 'st2::stanley':
   ssh_key_type => 'ssh-rsa',
   ssh_public_key => 'AAAAAWESOMEKEY==',
   ssh_private_key => '----- BEGIN RSA PRIVATE KEY -----\nDEADBEEF\n----- END RSA PRIVATE KEY -----',
@@ -2672,7 +2672,7 @@ include st2::timersengine
 ##### Customizing parameters
 
 ```puppet
-class { '::st2::timersengine':
+class { 'st2::timersengine':
   enabled  => true,
   timezone => 'America/Los_Angeles',
 }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@
 #       chmod 440 -R /etc/sudoers.d
 #
 #   - Run puppet to install StackStorm
-#       puppet apply -e "include ::st2::profile::fullinstall"
+#       puppet apply -e "include st2::profile::fullinstall"
 #
 #   - Keep editing files locally and re-running puppet with the command above
 
@@ -43,7 +43,7 @@ provider   = provider.to_sym
 #  - generic/ubuntu1404
 #  - generic/ubuntu1604
 #  - generic/ubuntu1804
-box        = ENV['BOX'] ? ENV['BOX'] : 'centos/7'
+box        = ENV['BOX'] ? ENV['BOX'] : 'generic/centos8'
 #box        = ENV['BOX'] ? ENV['BOX'] : 'generic/ubuntu1604'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!

--- a/build/centos6-puppet5/Puppetfile
+++ b/build/centos6-puppet5/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/centos6-puppet6/Puppetfile
+++ b/build/centos6-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/centos7-puppet5/Puppetfile
+++ b/build/centos7-puppet5/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/ubuntu14-puppet5/Puppetfile
+++ b/build/ubuntu14-puppet5/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/ubuntu14-puppet6/Puppetfile
+++ b/build/ubuntu14-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/ubuntu16-puppet5/Puppetfile
+++ b/build/ubuntu16-puppet5/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/ubuntu16-puppet6/Puppetfile
+++ b/build/ubuntu16-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9,7 +9,7 @@
 - Remove unused code
   - Tiller
   - Unused variables in this like st2::params
-  - Unused class level parameters in things like ::st2
+  - Unused class level parameters in things like st2
 - Cleanup class level comments
 - More unit tests
 - InSpec integration verification tests for kitchen

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -88,7 +88,7 @@ gem install puppet_forge:2.2.6 r10k
 r10k puppetfile install -v --moduledir=./modules --puppetfile=./docs/Puppetfile
 
 # run StackStorm full install using puppet
-puppet apply --modulepath=./modules -e "include ::st2::profile::fullinstall"
+puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 
 ```
 

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -9,4 +9,4 @@
 # Learn more about module testing here:
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
-include ::stackstorm
+include st2

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -29,7 +29,7 @@
 # @param ssl_key
 #    Path to SSL Key file (default: '/etc/ssl/st2/st2.key')
 #
-# @example Basic usage (via ::st2)
+# @example Basic usage (via st2)
 #  class { '::st2':
 #    auth_backend        => 'flat_file',
 #    auth_backend_config => {
@@ -43,7 +43,7 @@
 #    htpasswd_file: "/etc/something/htpasswd"
 #
 # @example Direct usage (default Flat File auth backend)
-#  include ::st2::auth
+#  include st2::auth
 #
 # @example Direct usage to configure a specific auth backend
 #  class { 'st2::auth':
@@ -64,7 +64,7 @@ class st2::auth (
   $use_ssl        = $::st2::use_ssl,
   $ssl_cert       = $::st2::ssl_cert,
   $ssl_key        = $::st2::ssl_key,
-) inherits ::st2 {
+) inherits st2 {
 
   if !defined(Class['::st2::auth::common']) {
     class { '::st2::auth::common':

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -30,7 +30,7 @@
 #    Path to SSL Key file (default: '/etc/ssl/st2/st2.key')
 #
 # @example Basic usage (via st2)
-#  class { '::st2':
+#  class { 'st2':
 #    auth_backend        => 'flat_file',
 #    auth_backend_config => {
 #      htpasswd_file => '/etc/something/htpasswd',
@@ -66,8 +66,8 @@ class st2::auth (
   $ssl_key        = $::st2::ssl_key,
 ) inherits st2 {
 
-  if !defined(Class['::st2::auth::common']) {
-    class { '::st2::auth::common':
+  if !defined(Class['st2::auth::common']) {
+    class { 'st2::auth::common':
       debug    => $debug,
       mode     => $mode,
       use_ssl  => $use_ssl,
@@ -78,11 +78,11 @@ class st2::auth (
 
   # instantiate a backend
   $_backend_class = $backend ? {
-    'flat_file' => '::st2::auth::flat_file',
-    'keystone'  => '::st2::auth::keystone',
-    'ldap'      => '::st2::auth::ldap',
-    'mongodb'   => '::st2::auth::mongodb',
-    'pam'       => '::st2::auth::pam',
+    'flat_file' => 'st2::auth::flat_file',
+    'keystone'  => 'st2::auth::keystone',
+    'ldap'      => 'st2::auth::ldap',
+    'mongodb'   => 'st2::auth::mongodb',
+    'pam'       => 'st2::auth::pam',
     default     => undef,
   }
   if $_backend_class == undef {

--- a/manifests/auth/common.pp
+++ b/manifests/auth/common.pp
@@ -25,7 +25,7 @@ class st2::auth::common (
   $use_ssl   = $::st2::use_ssl,
   $ssl_cert  = $::st2::ssl_cert,
   $ssl_key   = $::st2::ssl_key,
-) inherits ::st2 {
+) inherits st2 {
 
   $_debug = $debug ? {
     true    => 'True',

--- a/manifests/auth/flat_file.pp
+++ b/manifests/auth/flat_file.pp
@@ -10,7 +10,7 @@
 #   Path to htpasswd file (default: /etc/st2/htpasswd)
 #
 # @example Instantiate via st2
-#  class { '::st2':
+#  class { 'st2':
 #    auth_backend        => 'flat_file',
 #    auth_backend_config => {
 #      htpasswd_file => '/etc/something/htpasswd',

--- a/manifests/auth/flat_file.pp
+++ b/manifests/auth/flat_file.pp
@@ -9,7 +9,7 @@
 # @param htpasswd_file
 #   Path to htpasswd file (default: /etc/st2/htpasswd)
 #
-# @example Instantiate via ::st2
+# @example Instantiate via st2
 #  class { '::st2':
 #    auth_backend        => 'flat_file',
 #    auth_backend_config => {
@@ -27,8 +27,8 @@ class st2::auth::flat_file(
   $cli_password  = $::st2::cli_password,
   $conf_file     = $::st2::conf_file,
   $htpasswd_file = $::st2::params::auth_htpasswd_file,
-) inherits ::st2 {
-  include ::st2::auth::common
+) inherits st2 {
+  include st2::auth::common
 
   $_auth_users = hiera_hash('st2::auth_users', {})
 

--- a/manifests/auth/keystone.pp
+++ b/manifests/auth/keystone.pp
@@ -10,7 +10,7 @@
 # @param keystone_version
 #    Keystone API version (default: '2')
 #
-# @example Instantiate via ::st2
+# @example Instantiate via st2
 #  class { '::st2':
 #    auth_backend        => 'keystone',
 #    auth_backend_config => {
@@ -29,8 +29,8 @@ class st2::auth::keystone (
   $conf_file        = $::st2::conf_file,
   $keystone_url     = 'http://127.0.0.1:5000',
   $keystone_version = '2',
-) inherits ::st2 {
-  include ::st2::auth::common
+) inherits st2 {
+  include st2::auth::common
 
   # config
   ini_setting { 'auth_backend':

--- a/manifests/auth/keystone.pp
+++ b/manifests/auth/keystone.pp
@@ -11,7 +11,7 @@
 #    Keystone API version (default: '2')
 #
 # @example Instantiate via st2
-#  class { '::st2':
+#  class { 'st2':
 #    auth_backend        => 'keystone',
 #    auth_backend_config => {
 #      keystone_url     => 'http://keystone.domain.tld:5000',

--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -39,7 +39,7 @@
 # @param ref_hop_limit
 #    The maximum number to refer Referrals recursively (default: 0)
 #
-# @example Instantiate via ::st2 (Active Directory)
+# @example Instantiate via st2 (Active Directory)
 #  class { '::st2':
 #    auth_backend        => 'ldap',
 #    auth_backend_config => {
@@ -77,8 +77,8 @@ class st2::auth::ldap (
   $group           = undef,
   $chase_referrals = true,
   $ref_hop_limit   = 0,
-) inherits ::st2 {
-  include ::st2::auth::common
+) inherits st2 {
+  include st2::auth::common
 
   $_use_tls = bool2str($use_tls)
   $_chase_refs = bool2str($chase_referrals)

--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -40,7 +40,7 @@
 #    The maximum number to refer Referrals recursively (default: 0)
 #
 # @example Instantiate via st2 (Active Directory)
-#  class { '::st2':
+#  class { 'st2':
 #    auth_backend        => 'ldap',
 #    auth_backend_config => {
 #      ldap_uri      => 'ldaps://ldap.domain.tld',

--- a/manifests/auth/mongodb.pp
+++ b/manifests/auth/mongodb.pp
@@ -18,7 +18,7 @@
 # @param db_password
 #    Password for MongoDB login (default: st2auth)
 #
-# @example Instantiate via ::st2
+# @example Instantiate via st2
 #  class { '::st2':
 #    auth_backend        => 'mongodb',
 #    auth_backend_config => {
@@ -43,8 +43,8 @@ class st2::auth::mongodb (
   $db_auth     = $::st2::mongodb_auth,
   $db_username = $::st2::db_username,
   $db_password = $::st2::db_password,
-) inherits ::st2 {
-  include ::st2::auth::common
+) inherits st2 {
+  include st2::auth::common
 
   if $db_auth {
     $_kwargs = "{\"db_host\": \"${db_host}\", \"db_port\": \"${db_port}\",\

--- a/manifests/auth/mongodb.pp
+++ b/manifests/auth/mongodb.pp
@@ -19,7 +19,7 @@
 #    Password for MongoDB login (default: st2auth)
 #
 # @example Instantiate via st2
-#  class { '::st2':
+#  class { 'st2':
 #    auth_backend        => 'mongodb',
 #    auth_backend_config => {
 #      db_host => 'mongodb.stackstorm.net',

--- a/manifests/auth/pam.pp
+++ b/manifests/auth/pam.pp
@@ -8,7 +8,7 @@
 # @param conf_file
 #   The path where st2 config is stored
 #
-# @example Instantiate via ::st2
+# @example Instantiate via st2
 #  class { '::st2':
 #    backend => 'pam',
 #  }
@@ -19,8 +19,8 @@
 #
 class st2::auth::pam(
   $conf_file = $::st2::conf_file,
-) inherits ::st2 {
-  include ::st2::auth::common
+) inherits st2 {
+  include st2::auth::common
 
   # config
   ini_setting { 'auth_backend':

--- a/manifests/auth/pam.pp
+++ b/manifests/auth/pam.pp
@@ -9,7 +9,7 @@
 #   The path where st2 config is stored
 #
 # @example Instantiate via st2
-#  class { '::st2':
+#  class { 'st2':
 #    backend => 'pam',
 #  }
 #

--- a/manifests/auth_user.pp
+++ b/manifests/auth_user.pp
@@ -16,7 +16,7 @@ define st2::auth_user(
   $ensure   = present,
   $password = undef,
 ) {
-  include ::st2::auth::flat_file
+  include st2::auth::flat_file
   $_htpasswd_file = $::st2::auth::flat_file::htpasswd_file
 
   httpauth { $name:

--- a/manifests/client/settings.pp
+++ b/manifests/client/settings.pp
@@ -32,7 +32,7 @@
 #    Enable silencing SSL warnings for self-signed certs
 #
 # @example Basic usage
-#   ::st2::client::settings { 'john':
+#   st2::client::settings { 'john':
 #     username => 'st2_john',
 #     password => 'xyz123',
 #   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,17 +191,17 @@
 #
 # @example Customizing parameters
 #   # best practice is to change default username/password
-#   class { '::st2::params':
+#   class { 'st2::params':
 #     admin_username => 'st2admin',
 #     admin_password => 'SuperSecret!',
 #   }
 #
-#   class { '::st2':
+#   class { 'st2':
 #     version => '2.10.1',
 #   }
 #
 # @example Different passwords for each database (MongoDB, RabbitMQ, Postgres)
-#   class { '::st2':
+#   class { 'st2':
 #     # StackStorm user
 #     cli_username        => 'st2admin',
 #     cli_password        => 'SuperSecret!',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -184,7 +184,7 @@
 #
 #
 # @example Basic Usage
-#   include ::st2
+#   include st2
 #
 # @example Variables can be set in Hiera and take advantage of automatic data bindings:
 #   st2::version: 2.10.1

--- a/manifests/kv.pp
+++ b/manifests/kv.pp
@@ -15,7 +15,7 @@ define st2::kv (
   $ensure = present,
   $key    = $name,
 ) {
-  include ::st2
+  include st2
 
   exec { "set-st2-key-${key}":
     command   => "st2 key set ${key} ${value}",

--- a/manifests/logging/rsyslog.pp
+++ b/manifests/logging/rsyslog.pp
@@ -5,7 +5,7 @@
 # places.
 #
 # @example Basic usage
-#  include ::st2::logging::rsyslog
+#  include st2::logging::rsyslog
 class st2::logging::rsyslog {
   file { '/etc/rsyslog.d/10-st2.conf':
     ensure => file,

--- a/manifests/notices.pp
+++ b/manifests/notices.pp
@@ -2,12 +2,21 @@
 # @note Please do not call directly
 #
 class st2::notices {
-  include '::st2::params'
+  include 'st2::params'
 
-  $user_missing_client_keys = 'ssh_public_key and ssh_key_type need to be supplied for this resource. Help can be found in INSTALL.md if needed'
+  $user_missing_client_keys = @("EOF"/L)
+    ssh_public_key and ssh_key_type need to be supplied for this resource.
+    Help can be found in INSTALL.md if needed
+    |-EOF
+
   $user_missing_private_key = 'ssh_private_key needs to be supplied for this resource. Help can be found in INSTALL.md if needed'
   $unsupported_os = 'Your platform is not yet supported. Please file a bug or submit a bug to https://github.com/StackStorm/st2'
   $auth_test_user_enabled = 'The test user for the WebUI is **ENABLED**. Ensure to disable before deploying to production'
-  $web_no_oauth_token = 'The Web Interface is currently in limited beta. You will need a key to test this out. Please email us at support@stackstorm.com if you are interested in trying it out and providing feedback'
+  $web_no_oauth_token =  @("EOF"/L)
+    The Web Interface is currently in limited beta.
+    You will need a key to test this out.
+    Please email us at support@stackstorm.com if you are interested in trying it
+    out and providing feedback
+    |-EOF
 
 }

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -21,7 +21,7 @@ define st2::pack (
   $repo_url = undef,
   $config   = undef,
 ) {
-  include ::st2
+  include st2
   $_cli_username = $::st2::cli_username
   $_cli_password = $::st2::cli_password
   $_st2_packs_group = $::st2::params::packs_group_name

--- a/manifests/packs.pp
+++ b/manifests/packs.pp
@@ -22,6 +22,6 @@
 #
 class st2::packs (
   $packs = $::st2::packs,
-) inherits ::st2 {
+) inherits st2 {
   create_resources('::st2::pack', $packs)
 }

--- a/manifests/packs.pp
+++ b/manifests/packs.pp
@@ -3,7 +3,7 @@
 # @see st2::pack and st2::pack::config for usage
 #
 # @example Basic Usage
-#  class { '::st2::packs':
+#  class { 'st2::packs':
 #    packs => {
 #      puppet => {},
 #      influxdb => {
@@ -23,5 +23,5 @@
 class st2::packs (
   $packs = $::st2::packs,
 ) inherits st2 {
-  create_resources('::st2::pack', $packs)
+  create_resources('st2::pack', $packs)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@
 #   Password of the StackStorm admin user. Best practice is to change this to a unique password.
 #
 # @example Best Practice
-#   class { '::st2::params':
+#   class { 'st2::params':
 #     admin_username => 'myuser',
 #     admin_password => 'SuperSecret!',
 #   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 #   The name of the group created to hold the st2 admin user
 # @param hostname
 #   Hostname of the StackStorm box. This is used as the default to drive a lot of
-#   other parameters in the ::st2 class such as auth URL, MongoDB host, RabbitMQ host, etc.
+#   other parameters in the st2 class such as auth URL, MongoDB host, RabbitMQ host, etc.
 # @param admin_username
 #   Username of the StackStorm admin user. Best practice is to change this to a unique username.
 # @param admin_password
@@ -15,7 +15,7 @@
 #     admin_username => 'myuser',
 #     admin_password => 'SuperSecret!',
 #   }
-#   include ::st2::profile::fullinstall
+#   include st2::profile::fullinstall
 #
 class st2::params(
   $packs_group_name = 'st2packs',

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -42,7 +42,7 @@
 #    Used if +api_key+ is not specified (optional)
 #
 # @example Basic Usage
-#   class { '::st2':
+#   class { 'st2':
 #     chatops_hubot_name => '"@RosieRobot"',
 #     chatops_api_key    => '"xxxxyyyyy123abc"',
 #     chatops_adapter    => {
@@ -80,7 +80,7 @@ class st2::profile::chatops (
   $auth_username                = $::st2::cli_username,
   $auth_password                = $::st2::cli_password,
 ) inherits st2 {
-  include '::st2::params'
+  include 'st2::params'
 
   $_chatops_packages = $::st2::params::st2_chatops_packages
   $_chatops_dir = $::st2::params::st2_chatops_dir
@@ -125,7 +125,7 @@ class st2::profile::chatops (
     tag     => 'st2::chatops::npm_package',
   }
 
-  create_resources('::nodejs::npm', $npm_packages, $npm_package_defaults)
+  create_resources('nodejs::npm', $npm_packages, $npm_package_defaults)
 
   ########################################
   ## Services

--- a/manifests/profile/chatops.pp
+++ b/manifests/profile/chatops.pp
@@ -116,7 +116,7 @@ class st2::profile::chatops (
 
   ########################################
   ## Additional nodejs packages
-  include ::st2::profile::nodejs
+  include st2::profile::nodejs
 
   $npm_package_defaults = {
     ensure  => present,

--- a/manifests/profile/client.pp
+++ b/manifests/profile/client.pp
@@ -38,7 +38,7 @@ class st2::profile::client (
   $debug                = $::st2::cli_debug,
   $cache_token          = $::st2::cli_cache_token,
   $silence_ssl_warnings = $::st2::cli_silence_ssl_warnings,
-) inherits ::st2 {
+) inherits st2 {
 
   # Setup st2client settings for Root user by default
   st2::client::settings { 'root':

--- a/manifests/profile/facter.pp
+++ b/manifests/profile/facter.pp
@@ -4,5 +4,5 @@
 #  include st2::profile::facter
 #
 class st2::profile::facter {
-  include ::facter
+  include facter
 }

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -14,7 +14,7 @@
 #
 # @example Customizing parameters
 #   # Customizations are done via the main st2 class
-#   class { '::st2':
+#   class { 'st2':
 #     # ... assign custom parameters
 #   }
 #
@@ -30,20 +30,20 @@ class st2::profile::fullinstall inherits st2 {
 
   Anchor['st2::begin']
   -> Anchor['st2::bootstrap']
-  -> class { '::st2::profile::facter': }
-  -> class { '::st2::profile::repos': }
-  -> class { '::st2::profile::selinux': }
+  -> class { 'st2::profile::facter': }
+  -> class { 'st2::profile::repos': }
+  -> class { 'st2::profile::selinux': }
   -> Anchor['st2::pre_reqs']
-  -> class { '::st2::profile::nodejs': }
-  -> class { '::st2::profile::postgresql': }
-  -> class { '::st2::profile::rabbitmq': }
-  -> class { '::st2::profile::mongodb': }
+  -> class { 'st2::profile::nodejs': }
+  -> class { 'st2::profile::postgresql': }
+  -> class { 'st2::profile::rabbitmq': }
+  -> class { 'st2::profile::mongodb': }
   -> Anchor['st2::main']
-  -> class { '::st2::profile::mistral': }
-  -> class { '::st2::profile::client': }
-  -> class { '::st2::profile::server': }
-  -> class { '::st2::profile::web': }
-  -> class { '::st2::profile::chatops': }
+  -> class { 'st2::profile::mistral': }
+  -> class { 'st2::profile::client': }
+  -> class { 'st2::profile::server': }
+  -> class { 'st2::profile::web': }
+  -> class { 'st2::profile::chatops': }
   -> Anchor['st2::end']
 
   include st2::auth

--- a/manifests/profile/fullinstall.pp
+++ b/manifests/profile/fullinstall.pp
@@ -10,15 +10,15 @@
 #  * Mistral
 #
 # @example Basic Usage
-#   include ::st2::profile::fullinstall
+#   include st2::profile::fullinstall
 #
 # @example Customizing parameters
-#   # Customizations are done via the main ::st2 class
+#   # Customizations are done via the main st2 class
 #   class { '::st2':
 #     # ... assign custom parameters
 #   }
 #
-#   include ::st2::profile::fullinstall
+#   include st2::profile::fullinstall
 #
 class st2::profile::fullinstall inherits st2 {
 
@@ -46,9 +46,9 @@ class st2::profile::fullinstall inherits st2 {
   -> class { '::st2::profile::chatops': }
   -> Anchor['st2::end']
 
-  include ::st2::auth
-  include ::st2::packs
-  include ::st2::kvs
+  include st2::auth
+  include st2::packs
+  include st2::kvs
 
   # If user has not defined a pack "st2", install it from the Exchange.
   if ! defined(St2::Pack['st2']) {

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -22,7 +22,7 @@
 #    RabbitMQ virtual host for Mistral
 #
 # @example Basic Usage
-#  include ::st2::profile::mistral
+#  include st2::profile::mistral
 #
 # @example External database
 #  class { '::st2::profile::mistral':
@@ -50,7 +50,7 @@ class st2::profile::mistral(
   $rabbitmq_port     = $::st2::rabbitmq_port,
   $rabbitmq_vhost    = $::st2::rabbitmq_vhost,
 ) inherits st2 {
-  include ::st2::params
+  include st2::params
 
   ### Mistral Variables ###
   $mistral_root = '/opt/stackstorm/mistral'

--- a/manifests/profile/mistral.pp
+++ b/manifests/profile/mistral.pp
@@ -25,14 +25,14 @@
 #  include st2::profile::mistral
 #
 # @example External database
-#  class { '::st2::profile::mistral':
+#  class { 'st2::profile::mistral':
 #    db_host     => 'postgres.domain.tld',
 #    db_username => 'mistral',
 #    db_password => 'xyz123',
 #  }
 #
 # @example External RabbitMQ
-#  class { '::st2::profile::mistral':
+#  class { 'st2::profile::mistral':
 #    rabbitmq_hostname => 'rabbitmq.domain.tld',
 #    rabbitmq_username => 'mistral',
 #    rabbitmq_password => 'xyz123',
@@ -107,7 +107,7 @@ class st2::profile::mistral(
     password_hash => postgresql_password($db_username, $db_password),
     createdb      => true,
     before        => Postgresql::Server::Database[$db_name],
-    require       => Class['::postgresql::server'],
+    require       => Class['postgresql::server'],
   }
 
   postgresql::server::database { $db_name:

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -21,7 +21,7 @@
 #   include st2::profile::mongodb
 #
 # @example Customize (done via st2)
-#   class { '::st2':
+#   class { 'st2':
 #     db_name     => 'stackstormdb',
 #     db_username => 'abc',
 #     db_password => 'xyz123',
@@ -56,9 +56,9 @@ class st2::profile::mongodb (
     default => $version,
   }
 
-  if !defined(Class['::mongodb::server']) {
+  if !defined(Class['mongodb::server']) {
 
-    class { '::mongodb::globals':
+    class { 'mongodb::globals':
       manage_package      => true,
       manage_package_repo => $manage_repo,
       version             => $_mongodb_version,
@@ -66,10 +66,10 @@ class st2::profile::mongodb (
       manage_pidfile      => false, # mongo will not start if this is true
     }
 
-    class { '::mongodb::client': }
+    class { 'mongodb::client': }
 
     if $auth == true {
-      class { '::mongodb::server':
+      class { 'mongodb::server':
         port           => $db_port,
         auth           => true,
         create_admin   => true,
@@ -179,7 +179,7 @@ class st2::profile::mongodb (
       }
     }
     else {
-      class { '::mongodb::server':
+      class { 'mongodb::server':
         port => $db_port,
       }
     }
@@ -241,7 +241,7 @@ class st2::profile::mongodb (
       user     => $db_username,
       password => $db_password,
       roles    => $::st2::params::mongodb_st2_roles,
-      require  => Class['::mongodb::server'],
+      require  => Class['mongodb::server'],
     }
   }
 

--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -18,16 +18,16 @@
 #    Boolean determining if auth should be enabled for MongoDB.
 #
 # @example Basic Usage
-#   include ::st2::profile::mongodb
+#   include st2::profile::mongodb
 #
-# @example Customize (done via ::st2)
+# @example Customize (done via st2)
 #   class { '::st2':
 #     db_name     => 'stackstormdb',
 #     db_username => 'abc',
 #     db_password => 'xyz123',
 #     db_port     => 12345,
 #   }
-#   include ::st2::profile::mongodb
+#   include st2::profile::mongodb
 #
 class st2::profile::mongodb (
   $db_name     = $::st2::db_name,
@@ -95,7 +95,7 @@ class st2::profile::mongodb (
 
         # unfortinately there is no way to synchronously force a service restart
         # in Puppet, so we have to revert to exec... sorry
-        include ::mongodb::params
+        include mongodb::params
         if (($::osfamily == 'Debian' and $::operatingsystemmajrelease == '14.04') or
             ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6')) {
           $_mongodb_stop_cmd = "service ${::mongodb::params::service_name} stop"

--- a/manifests/profile/nginx.pp
+++ b/manifests/profile/nginx.pp
@@ -9,7 +9,7 @@
 class st2::profile::nginx (
   $manage_repo = $::st2::nginx_manage_repo
 ) inherits st2 {
-  class { '::nginx':
+  class { 'nginx':
     manage_repo => $manage_repo,
     confd_purge => false,
   }

--- a/manifests/profile/nodejs.pp
+++ b/manifests/profile/nodejs.pp
@@ -49,13 +49,13 @@ class st2::profile::nodejs(
   if ($::osfamily == 'RedHat' and
       versioncmp($::operatingsystemmajrelease, '7') >= 0) {
     if $use_rhel7_builtin {
-      class { '::nodejs':
+      class { 'nodejs':
         manage_package_repo => false,
         npm_package_ensure  => 'present',
       }
     }
     else {
-      class { '::nodejs':
+      class { 'nodejs':
         repo_url_suffix     => $nodejs_version,
         manage_package_repo => $manage_repo,
       }
@@ -74,7 +74,7 @@ class st2::profile::nodejs(
   }
   else {
     # install nodejs from nodesource repo
-    class { '::nodejs':
+    class { 'nodejs':
       repo_url_suffix     => $nodejs_version,
       manage_package_repo => $manage_repo,
     }

--- a/manifests/profile/postgresql.pp
+++ b/manifests/profile/postgresql.pp
@@ -1,7 +1,7 @@
 # @summary st2 compatable installation of PostgreSQL and dependencies for use with StackStorm and Mistral.
 #
 # @example Basic usage
-#   include ::st2::profile::postgresql
+#   include st2::profile::postgresql
 #
 # @example Customizing parameters
 #   class { '::st2::profile::postgresql':

--- a/manifests/profile/postgresql.pp
+++ b/manifests/profile/postgresql.pp
@@ -4,7 +4,7 @@
 #   include st2::profile::postgresql
 #
 # @example Customizing parameters
-#   class { '::st2::profile::postgresql':
+#   class { 'st2::profile::postgresql':
 #     db_bind_ips => '0.0.0.0',
 #   }
 #
@@ -14,15 +14,15 @@
 class st2::profile::postgresql(
   $bind_ips = $::st2::mistral_db_bind_ips,
 ) inherits st2 {
-  if !defined(Class['::postgresql::server']) {
+  if !defined(Class['postgresql::server']) {
     if ($::osfamily == 'RedHat') and ($::operatingsystemmajrelease == '6') {
-      class { '::postgresql::globals':
+      class { 'postgresql::globals':
         version             => '9.4',
         manage_package_repo => true,
       }
     }
 
-    class { '::postgresql::server':
+    class { 'postgresql::server':
       listen_addresses => $bind_ips,
     }
   }

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -20,8 +20,8 @@ class st2::profile::python {
       require => Package['python27'],
     }
   } else {
-    if !defined(Class['::python']) {
-      class { '::python':
+    if !defined(Class['python']) {
+      class { 'python':
         version    => 'system',
         pip        => present,
         dev        => true,

--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -14,7 +14,7 @@
 # @example Basic Usage
 #   include st2::profile::rabbitmq
 #
-# @example Authentication enabled (configured vi ::st2)
+# @example Authentication enabled (configured vi st2)
 #   class { '::st2':
 #     rabbitmq_username => 'rabbitst2',
 #     rabbitmq_password => 'secret123',

--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -15,7 +15,7 @@
 #   include st2::profile::rabbitmq
 #
 # @example Authentication enabled (configured vi st2)
-#   class { '::st2':
+#   class { 'st2':
 #     rabbitmq_username => 'rabbitst2',
 #     rabbitmq_password => 'secret123',
 #   }
@@ -31,7 +31,7 @@ class st2::profile::rabbitmq (
 
   # In new versions of the RabbitMQ module we need to explicitly turn off
   # the ranch TCP settings so that Kombu can connect via AMQP
-  class { '::rabbitmq' :
+  class { 'rabbitmq' :
     config_ranch          => false,
     delete_guest_user     => true,
     port                  => $port,
@@ -39,7 +39,7 @@ class st2::profile::rabbitmq (
       'RABBITMQ_NODE_IP_ADDRESS' => $::st2::rabbitmq_bind_ip,
     },
   }
-  contain '::rabbitmq'
+  contain 'rabbitmq'
 
   rabbitmq_user { $username:
     admin    => true,
@@ -58,11 +58,11 @@ class st2::profile::rabbitmq (
 
   # RHEL needs EPEL installed prior to rabbitmq
   if $::osfamily == 'RedHat' {
-    Class['::epel']
-    -> Class['::rabbitmq']
+    Class['epel']
+    -> Class['rabbitmq']
 
     Yumrepo['epel']
-    -> Class['::rabbitmq']
+    -> Class['rabbitmq']
 
     Yumrepo['epel']
     -> Package['rabbitmq-server']

--- a/manifests/profile/repos.pp
+++ b/manifests/profile/repos.pp
@@ -1,7 +1,7 @@
 # @summary Manages the installation of st2 required repos for installing the StackStorm packages.
 #
 # @example Basic usage
-#   include ::st2::profile::repos
+#   include st2::profile::repos
 #
 # @example Installing from unstable
 #   class { '::st2::profile::repos':
@@ -17,10 +17,10 @@ class st2::profile::repos(
   $repository   = $::st2::repository,
   $package_type = $::st2::params::package_type,
 ) inherits st2 {
-  require ::packagecloud
+  require packagecloud
 
   if $::osfamily == 'RedHat' {
-    require ::epel
+    require epel
   }
   $_packagecloud_repo = "StackStorm/${repository}"
   packagecloud::repo { $_packagecloud_repo:

--- a/manifests/profile/repos.pp
+++ b/manifests/profile/repos.pp
@@ -4,7 +4,7 @@
 #   include st2::profile::repos
 #
 # @example Installing from unstable
-#   class { '::st2::profile::repos':
+#   class { 'st2::profile::repos':
 #     repository => 'unstable',
 #   }
 #

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -66,8 +66,8 @@ class st2::profile::server (
   $rabbitmq_vhost         = $::st2::rabbitmq_vhost,
   $index_url              = $::st2::index_url,
 ) inherits st2 {
-  include ::st2::notices
-  include ::st2::params
+  include st2::notices
+  include st2::params
 
   $_enable_auth = $auth ? {
     true    => 'True',
@@ -339,9 +339,9 @@ class st2::profile::server (
     tag    => 'st2::service',
   }
 
-  contain ::st2::scheduler
-  contain ::st2::timersengine
-  contain ::st2::workflowengine
+  contain st2::scheduler
+  contain st2::timersengine
+  contain st2::workflowengine
 
   ########################################
   ## st2 user (stanley)

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -345,11 +345,11 @@ class st2::profile::server (
 
   ########################################
   ## st2 user (stanley)
-  class { '::st2::stanley': }
+  class { 'st2::stanley': }
 
   ########################################
   ## Datastore keys
-  class { '::st2::server::datastore_keys': }
+  class { 'st2::server::datastore_keys': }
 
   ########################################
   ## Dependencies
@@ -358,11 +358,11 @@ class st2::profile::server (
   ~> Service<| tag == 'st2::service' |>
 
   Package<| tag == 'st2::server::packages' |>
-  -> Class['::st2::server::datastore_keys']
+  -> Class['st2::server::datastore_keys']
   -> Service<| tag == 'st2::service' |>
 
   Package<| tag == 'st2::server::packages' |>
-  -> Class['::st2::stanley']
+  -> Class['st2::stanley']
   -> Service<| tag == 'st2::service' |>
 
   Package<| tag == 'st2::server::packages' |>

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -13,7 +13,7 @@
 #    Version of StackStorm WebUI to install
 #
 # @example Basic Usage
-#   include ::st2::profile::web'
+#   include st2::profile::web'
 #
 class st2::profile::web(
   $ssl_dir  = $::st2::ssl_dir,
@@ -22,11 +22,11 @@ class st2::profile::web(
   $version  = $::st2::version,
 ) inherits st2 {
   # include nginx here only
-  # if we include this in ::st2::profile::fullinstall Anchor['pre_reqs'] then
+  # if we include this in st2::profile::fullinstall Anchor['pre_reqs'] then
   # a dependency cycle is created because we must modify the nginx config
   # in this profile.
-  include ::st2::profile::nginx
-  include ::st2::params
+  include st2::profile::nginx
+  include st2::params
 
   ## Install the packages
   package { $::st2::params::st2_web_packages:

--- a/manifests/rbac.pp
+++ b/manifests/rbac.pp
@@ -27,28 +27,28 @@ define st2::rbac (
     'owner'   => 'root',
     'group'   => 'root',
     'mode'    => '0755',
-    'require' => Class['::st2::profile::server'],
+    'require' => Class['st2::profile::server'],
   })
   ensure_resource('file', "${_rbac_dir}/assignments", {
     'ensure'  => 'directory',
     'owner'   => 'root',
     'group'   => 'root',
     'mode'    => '0755',
-    'require' => Class['::st2::profile::server'],
+    'require' => Class['st2::profile::server'],
   })
   ensure_resource('file', "${_rbac_dir}/roles", {
     'ensure'  => 'directory',
     'owner'   => 'root',
     'group'   => 'root',
     'mode'    => '0755',
-    'require' => Class['::st2::profile::server'],
+    'require' => Class['st2::profile::server'],
   })
   ensure_resource('file', "${_rbac_dir}/assignments", {
     'ensure'  => 'directory',
     'owner'   => 'root',
     'group'   => 'root',
     'mode'    => '0755',
-    'require' => Class['::st2::profile::server'],
+    'require' => Class['st2::profile::server'],
   })
   ensure_resource('exec', 'reload st2 rbac definitions', {
     'command'         => 'st2-apply-rbac-definitions',

--- a/manifests/scheduler.pp
+++ b/manifests/scheduler.pp
@@ -8,7 +8,7 @@
 # @see https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample#L251-L259
 #
 # @example Basic usage
-#   include ::st2::scheduler
+#   include st2::scheduler
 #
 # @example Customizing parameters
 #   class { '::st2::scheduler':

--- a/manifests/scheduler.pp
+++ b/manifests/scheduler.pp
@@ -11,7 +11,7 @@
 #   include st2::scheduler
 #
 # @example Customizing parameters
-#   class { '::st2::scheduler':
+#   class { 'st2::scheduler':
 #     sleep_interval => 60,
 #     gc_interval    => 120,
 #   }

--- a/manifests/server/datastore_keys.pp
+++ b/manifests/server/datastore_keys.pp
@@ -8,7 +8,7 @@
 #    Path to the key file
 #
 # @example Basic Usage
-#   include ::st2::server::datastore_keys
+#   include st2::server::datastore_keys
 #
 # @example Custom key path
 #   class { '::st2::server::datastore_keys':

--- a/manifests/server/datastore_keys.pp
+++ b/manifests/server/datastore_keys.pp
@@ -11,7 +11,7 @@
 #   include st2::server::datastore_keys
 #
 # @example Custom key path
-#   class { '::st2::server::datastore_keys':
+#   class { 'st2::server::datastore_keys':
 #     keys_dir => '/path/to/custom/keys',
 #     key_path => '/path/to/custom/keys/datastore_key.json.',
 #   }

--- a/manifests/stanley.pp
+++ b/manifests/stanley.pp
@@ -19,7 +19,7 @@
 #  include st2::stanley
 #
 # @example Custom SSH keys
-#  class { '::st2::stanley':
+#  class { 'st2::stanley':
 #    ssh_key_type => 'ssh-rsa',
 #    ssh_public_key => 'AAAAAWESOMEKEY==',
 #    ssh_private_key => '----- BEGIN RSA PRIVATE KEY -----\nDEADBEEF\n----- END RSA PRIVATE KEY -----',

--- a/manifests/stanley.pp
+++ b/manifests/stanley.pp
@@ -16,7 +16,7 @@
 #    Server where connection requests originate (usually st2 server)
 #
 # @example Basic Usage
-#  include ::st2::stanley
+#  include st2::stanley
 #
 # @example Custom SSH keys
 #  class { '::st2::stanley':

--- a/manifests/test/fullinstall.pp
+++ b/manifests/test/fullinstall.pp
@@ -1,2 +1,2 @@
 # Test for installing standalone StackStorm
-include ::st2::profile::fullinstall
+include st2::profile::fullinstall

--- a/manifests/timersengine.pp
+++ b/manifests/timersengine.pp
@@ -11,7 +11,7 @@
 #   include st2::timersengine
 #
 # @example Customizing parameters
-#   class { '::st2::timersengine':
+#   class { 'st2::timersengine':
 #     enabled  => true,
 #     timezone => 'America/Los_Angeles',
 #   }

--- a/manifests/timersengine.pp
+++ b/manifests/timersengine.pp
@@ -8,7 +8,7 @@
 # @see https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample#L337-L343
 #
 # @example Basic usage
-#   include ::st2::timersengine
+#   include st2::timersengine
 #
 # @example Customizing parameters
 #   class { '::st2::timersengine':

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -34,7 +34,7 @@ define st2::user(
   $groups            = undef,
   $ssh_dir           = "/home/${name}/.ssh",
 ) {
-  include ::st2::params
+  include st2::params
 
   $_packs_group_name = $st2::params::packs_group_name
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -39,8 +39,8 @@ define st2::user(
   $_packs_group_name = $st2::params::packs_group_name
 
   if $create_sudo_entry {
-    if !defined(Class['::sudo']) and !defined(Class['sudo']) {
-      class { '::sudo':
+    if !defined(Class['sudo']) and !defined(Class['sudo']) {
+      class { 'sudo':
         # do not purge files in /etc/sudoers.d/*
         purge               => false,
         # the 'enable' option (for some reason) purges all /etc/sudoers.d/* files

--- a/manifests/workflowengine.pp
+++ b/manifests/workflowengine.pp
@@ -8,10 +8,10 @@
 # @see https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample
 #
 # @example Basic usage
-#   include ::st2::workflowengine
+#   include st2::workflowengine
 #
 class st2::workflowengine {
-  include ::st2
+  include st2
 
   # st2workflowengine was introduced in 2.8.0
   if st2::version_ge('2.8.0') {

--- a/metadata.json
+++ b/metadata.json
@@ -95,7 +95,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.13.0",
-  "template-url": "pdk-default#1.13.0",
-  "template-ref": "1.13.0-0-g66e1443"
+  "pdk-version": "1.14.1",
+  "template-url": "pdk-default#1.14.1",
+  "template-ref": "1.14.1-0-g0b5b39b"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,5 +3,6 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/defines/pack_spec.rb
+++ b/spec/defines/pack_spec.rb
@@ -90,7 +90,7 @@ describe 'st2::pack' do
   end
 
   context 'when declared with non-default user and password' do
-    let(:pre_condition) { 'class {"::st2": cli_password => "test_bar", cli_username => "test_foo"}' }
+    let(:pre_condition) { 'class {"st2": cli_password => "test_bar", cli_username => "test_foo"}' }
 
     it do
       is_expected.to contain_st2_pack('st2testpack').with(

--- a/spec/functions/version_ge_spec.rb
+++ b/spec/functions/version_ge_spec.rb
@@ -17,7 +17,7 @@ describe 'st2::version_ge' do
 
   context 'when StackStorm is installed' do
     context 'and st2::version = "present"' do
-      let(:pre_condition) { "class {'::st2': version => 'present' }" }
+      let(:pre_condition) { "class {'st2': version => 'present' }" }
       let(:facts) do
         {
           st2_version: '2.9.0',
@@ -36,7 +36,7 @@ describe 'st2::version_ge' do
     end
 
     context 'and st2::version = "installed"' do
-      let(:pre_condition) { "class {'::st2': version => 'installed' }" }
+      let(:pre_condition) { "class {'st2': version => 'installed' }" }
       let(:facts) do
         {
           st2_version: '2.9.0',
@@ -55,7 +55,7 @@ describe 'st2::version_ge' do
     end
 
     context 'and st2::version = "latest"' do
-      let(:pre_condition) { "class {'::st2': version => 'latest' }" }
+      let(:pre_condition) { "class {'st2': version => 'latest' }" }
       let(:facts) do
         {
           st2_version: '2.9.0',
@@ -74,7 +74,7 @@ describe 'st2::version_ge' do
     end
 
     context 'and st2_version = "2.9.0" st2::version = "2.9.0"' do
-      let(:pre_condition) { "class {'::st2': version => '2.9.0' }" }
+      let(:pre_condition) { "class {'st2': version => '2.9.0' }" }
       let(:facts) do
         {
           st2_version: '2.9.0',
@@ -93,7 +93,7 @@ describe 'st2::version_ge' do
     end
 
     context 'and st2_version = "2.9.0" st2::version = "2.10.0"' do
-      let(:pre_condition) { "class {'::st2': version => '2.10.0' }" }
+      let(:pre_condition) { "class {'st2': version => '2.10.0' }" }
       let(:facts) do
         {
           st2_version: '2.9.0',
@@ -112,7 +112,7 @@ describe 'st2::version_ge' do
     end
 
     context 'and st2_version = "2.10.0" st2::version = "2.9.0"' do
-      let(:pre_condition) { "class {'::st2': version => '2.9.0' }" }
+      let(:pre_condition) { "class {'st2': version => '2.9.0' }" }
       let(:facts) do
         {
           st2_version: '2.10.0',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ end
 # Ensures that a module is defined
 # @param module_name Name of the module
 def ensure_module_defined(module_name)
-  module_name.split('::').reduce(Object) do |last_module, next_module|
+  module_name.split('').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
     last_module.const_get(next_module, false)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ end
 # Ensures that a module is defined
 # @param module_name Name of the module
 def ensure_module_defined(module_name)
-  module_name.split('').reduce(Object) do |last_module, next_module|
+  module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)
     last_module.const_get(next_module, false)
   end

--- a/test/integration/stackstorm/controls/rabbitmq_test.rb
+++ b/test/integration/stackstorm/controls/rabbitmq_test.rb
@@ -29,7 +29,7 @@ control 'rabbitmq' do
   describe port(5672) do
     it { should be_listening }
     its('processes') { should include 'beam.smp' }
-    its('addresses') { should be_in ['127.0.0.1', ''] }
+    its('addresses') { should be_in ['127.0.0.1', '::'] }
     its('protocols') { should cmp 'tcp' }
   end
 

--- a/test/integration/stackstorm/controls/rabbitmq_test.rb
+++ b/test/integration/stackstorm/controls/rabbitmq_test.rb
@@ -29,7 +29,7 @@ control 'rabbitmq' do
   describe port(5672) do
     it { should be_listening }
     its('processes') { should include 'beam.smp' }
-    its('addresses') { should be_in ['127.0.0.1', '::'] }
+    its('addresses') { should be_in ['127.0.0.1', ''] }
     its('protocols') { should cmp 'tcp' }
   end
 


### PR DESCRIPTION
Puppet recently changed their style guide and puppet-lint-absolute_classname-check updated to match.

Previously, the following was OK:

```puppet
include ::xyz
```

Now you're supposed to do:
```puppet
include xyz
```