### PR TITLE
Reverting to old version of train gem to fix build problems

### DIFF
--- a/build/kitchen/Gemfile
+++ b/build/kitchen/Gemfile
@@ -17,4 +17,6 @@ gem 'puppet'
 gem 'r10k'
 gem 'semverse'
 gem 'test-kitchen'
+# hard code to 3.2.0 because sudo bugs: https://github.com/inspec/train/issues/548
+gem 'train', '3.2.0'
 gem 'winrm-fs'


### PR DESCRIPTION
Recent build problems have been caused by a bug in the `train` gem on versions `> 3.2.0`: https://github.com/inspec/train/issues/548

This PR pins the `train` gem to `3.2.0` before the bug was introduced, causing `sudo` syntax errors when doing `inspec` verify.