### PR TITLE
Fixing puppet module dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Removed unused `puppet-wget` module dependency. (Enhancement)
   Contributed by @nmaludy
 
+- Define upper-bounds for puppet module dependencies. #282 (Enhancement)
+  Contributed by @nmaludy
+
 
 ## 1.5.0 (Oct 2, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Updated to new Puppet style guide where the leading `::` in class names is no longer
   acceptable. (Bugfix)
   Contributed by @nmaludy
+  
+- Removed unused `puppet-wget` module dependency. (Enhancement)
+  Contributed by @nmaludy
 
 
 ## 1.5.0 (Oct 2, 2019)

--- a/build/centos6-puppet5/Puppetfile
+++ b/build/centos6-puppet5/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/centos6-puppet6/Puppetfile
+++ b/build/centos6-puppet6/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/centos7-puppet5/Puppetfile
+++ b/build/centos7-puppet5/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profilek::fullinstall"
 #
 # #############
 # # DEV Notes #
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -8,7 +8,7 @@
 # r10k puppetfile install -v --moduledir=./modules --puppetfile=./Puppetfile
 # # to check the module dependencies here:
 # # puppet module list --tree --modulepath ./modules/
-# puppet apply --modulepath=./modules -e "include st2::profilek::fullinstall"
+# puppet apply --modulepath=./modules -e "include st2::profile::fullinstall"
 #
 # #############
 # # DEV Notes #

--- a/build/ubuntu14-puppet5/Puppetfile
+++ b/build/ubuntu14-puppet5/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/ubuntu14-puppet6/Puppetfile
+++ b/build/ubuntu14-puppet6/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/ubuntu16-puppet5/Puppetfile
+++ b/build/ubuntu16-puppet5/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/build/ubuntu16-puppet6/Puppetfile
+++ b/build/ubuntu16-puppet6/Puppetfile
@@ -26,7 +26,6 @@
 #   ├── puppetlabs-stdlib (v5.2.0)
 #   ├─┬ puppetlabs-apt (v6.3.0)
 #   │ └── puppetlabs-translate (v1.2.0)
-#   ├── puppet-wget (v2.0.1)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
 #   │ └── stahnma-epel (v1.3.1)
@@ -49,7 +48,6 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
 mod 'stahnma-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
-mod 'puppet-wget'
 mod 'saz-sudo'
 mod 'puppet-python'
 mod 'puppetlabs-inifile'

--- a/metadata.json
+++ b/metadata.json
@@ -25,10 +25,6 @@
       "version_requirement": ">= 1.1.0"
     },
     {
-      "name": "puppet/wget",
-      "version_requirement": ">= 1.5.6"
-    },
-    {
       "name": "saz/sudo",
       "version_requirement": ">= 3.0.9"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -10,63 +10,63 @@
   "dependencies": [
     {
       "name": "jamtur01/httpauth",
-      "version_requirement": ">= 0.0.3"
+      "version_requirement": ">= 0.0.3 < 1.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0"
+      "version_requirement": ">= 4.6.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.7.0"
+      "version_requirement": ">= 1.7.0 < 8.0.0"
     },
     {
       "name": "stahnma/epel",
-      "version_requirement": ">= 1.1.0"
+      "version_requirement": ">= 1.1.0 < 2.0.0"
     },
     {
       "name": "saz/sudo",
-      "version_requirement": ">= 3.0.9"
+      "version_requirement": ">= 3.0.9 < 7.0.0"
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 1.10.0"
+      "version_requirement": ">= 1.10.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.2.0"
+      "version_requirement": ">= 1.2.0 < 5.0.0"
     },
     {
       "name": "puppet/mongodb",
-      "version_requirement": ">= 0.14.0"
+      "version_requirement": ">= 0.14.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.4.2"
+      "version_requirement": ">= 4.4.2 < 7.0.0"
     },
     {
       "name": "puppet/rabbitmq",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.1.0 < 11.0.0"
     },
     {
       "name": "ghoneycutt/facter",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "computology/packagecloud",
-      "version_requirement": ">= 0.3.1"
+      "version_requirement": ">= 0.3.1 < 1.0.0"
     },
     {
       "name": "puppet/selinux",
-      "version_requirement": ">= 0.5.0"
+      "version_requirement": ">= 0.5.0 < 4.0.0"
     },
     {
       "name": "puppet/nginx",
-      "version_requirement": ">= 0.5.0"
+      "version_requirement": ">= 0.5.0 < 2.0.0"
     },
     {
       "name": "puppet/nodejs",
-      "version_requirement": ">= 1.3.0"
+      "version_requirement": ">= 1.3.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -91,7 +91,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.14.1",
-  "template-url": "pdk-default#1.14.1",
-  "template-ref": "1.14.1-0-g0b5b39b"
+  "pdk-version": "1.15.0",
+  "template-url": "pdk-default#1.15.0",
+  "template-ref": "tags/1.15.0-0-g0bc522e"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "puppet/mongodb",
-      "version_requirement": ">= 0.14.0 < 4.0.0"
+      "version_requirement": ">= 3.1.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
Closes #282 

In order for us to received the "Approved" status for a Puppet module we need to fix up some of our dependencies in `metadata.json`.

- Do not have any "open ended" dependencies, ie we need to define an upper bound.
- Do not have any unused dependencies.