### PR TITLE
[WIP] Convert integration test over to Litmus and ServerSpec

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,13 +16,13 @@ fixtures:
     mongodb: "puppet/mongodb"
     postgresql: "puppetlabs/postgresql"
     rabbitmq: "puppet/rabbitmq"
-    packagecloud: "computology/packagecloud"
     selinux: "puppet/selinux"
     nginx: "puppet/nginx"
     nodejs: "puppet/nodejs"
+    recursive_file_permissions: "npwalker/recursive_file_permissions"
   repositories:
     # needed for Litmus
     # https://github.com/puppetlabs/puppet_litmus/wiki/Converting-a-module-to-use-Litmus
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'https://github.com/puppetlabs/provision.git'
+    provision: 'https://github.com/nmaludy/provision.git'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,7 +9,6 @@ fixtures:
     apt: "puppetlabs/apt"
     epel: "stahnma/epel"
     concat: "puppetlabs/concat"
-    wget: "puppet/wget"
     sudo: "saz/sudo"
     python: "puppet/python"
     gcc: "puppetlabs/gcc"
@@ -21,3 +20,9 @@ fixtures:
     selinux: "puppet/selinux"
     nginx: "puppet/nginx"
     nodejs: "puppet/nodejs"
+  repositories:
+    # needed for Litmus
+    # https://github.com/puppetlabs/puppet_litmus/wiki/Converting-a-module-to-use-Litmus
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    provision: 'https://github.com/puppetlabs/provision.git'

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .coverage
 .librarian
 .kitchen
+.r10k
 .tmp
 .bundle
 /cover/

--- a/.sync.yml
+++ b/.sync.yml
@@ -56,5 +56,8 @@ Gemfile:
         version: '>= 0.3.0'
       - gem: 'puppet-lint-version_comparison-check'
         version: '>= 0.2.1'
+      - gem: 'puppet_litmus'
+        git: 'https://github.com/puppetlabs/puppet_litmus.git'
+      - gem: 'serverspec'
 spec/spec_helper.rb:
   mock_with: ':rspec'

--- a/.sync.yml
+++ b/.sync.yml
@@ -4,6 +4,7 @@
     - .coverage
     - .librarian
     - .kitchen
+    - .r10k
     - .tmp
     - .bundle
     - /cover/
@@ -25,6 +26,11 @@ appveyor.yml:
 Gemfile:
   required:
     ':development':
+      # needed for ed25519 support
+      - gem: 'bcrypt_pbkdf'
+        version: '>= 1.0.0'
+      - gem: 'ed25519'
+        version: '>= 1.2.0'
       - gem: 'puppet-lint-absolute_classname-check'
         # pin to 2.0.0 to comply with new standard which removes the leading ::
         version: '>= 2.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,12 @@ group :development do
   gem "json", '= 2.0.4',                                                       require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                                       require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                                require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3',               require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',                   require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',                 require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',                     require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4',               require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',                   require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',                 require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',                     require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "bcrypt_pbkdf", '>= 1.0.0',                                              require: false
+  gem "ed25519", '>= 1.2.0',                                                   require: false
   gem "puppet-lint-absolute_classname-check", '>= 2.0.0',                      require: false
   gem "puppet-lint-absolute_template_path", '>= 1.0.1',                        require: false
   gem "puppet-lint-alias-check", '>= 0.1.1',                                   require: false

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ group :development do
   gem "puppet-lint-trailing_comma-check", '>= 0.3.2',                          require: false
   gem "puppet-lint-unquoted_string-check", '>= 0.3.0',                         require: false
   gem "puppet-lint-version_comparison-check", '>= 0.2.1',                      require: false
+  gem "puppet_litmus",                                                         require: false, git: 'https://github.com/puppetlabs/puppet_litmus.git'
+  gem "serverspec",                                                            require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'

--- a/build/centos6-puppet5/Puppetfile
+++ b/build/centos6-puppet5/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/centos6-puppet6/Puppetfile
+++ b/build/centos6-puppet6/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/centos7-puppet5/Puppetfile
+++ b/build/centos7-puppet5/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/scripts/ci_litmus.sh
+++ b/build/scripts/ci_litmus.sh
@@ -3,9 +3,13 @@ set -e
 set -o xtrace
 
 TEST_NAME=docker_centos7
-PUPPET_COLLECTION=puppet5
+PUPPET_COLLECTION=puppet6
 bundle exec rake "litmus:provision_list[$TEST_NAME]"
-bundle exec bolt command run 'yum -y install wget' --inventoryfile inventory.yaml --targets='localhost*'
+# provisioner: docker
+# bundle exec bolt command run 'yum -y install wget' --inventoryfile inventory.yaml --targets='localhost*'
+
+# provisioner: docker_exp
+bundle exec bolt command run 'yum -y install wget' --inventoryfile inventory.yaml --targets='docker_nodes'
 bundle exec rake "litmus:install_agent[$PUPPET_COLLECTION]"
 bundle exec rake "litmus:install_module"
 bundle exec rake "litmus:acceptance:parallel"

--- a/build/scripts/ci_litmus.sh
+++ b/build/scripts/ci_litmus.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+set -o xtrace
+
+TEST_NAME=docker_centos7
+PUPPET_COLLECTION=puppet5
+bundle exec rake "litmus:provision_list[$TEST_NAME]"
+bundle exec bolt command run 'yum -y install wget' --inventoryfile inventory.yaml --targets='localhost*'
+bundle exec rake "litmus:install_agent[$PUPPET_COLLECTION]"
+bundle exec rake "litmus:install_module"
+bundle exec rake "litmus:acceptance:parallel"

--- a/build/scripts/ci_litmus_clean.sh
+++ b/build/scripts/ci_litmus_clean.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+set -o xtrace
+
+# Tear down all targets in inventory.yml
+bundle exec rake "litmus:tear_down"

--- a/build/scripts/install_puppet.sh
+++ b/build/scripts/install_puppet.sh
@@ -10,7 +10,7 @@ sudo /opt/puppetlabs/puppet/bin/gem install librarian-puppet
 sudo yum -y install git
 
 # Install puppet module dependencies
-sudo -i bash -c "pushd /vagrant/build/centos7-puppet6 && /opt/puppetlabs/puppet/bin/librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules"
+sudo -i bash -c "pushd /vagrant/build/ubuntu18-puppet6 && /opt/puppetlabs/puppet/bin/librarian-puppet install --verbose --path=/etc/puppetlabs/code/modules"
 
 # Create symlink for the st2/ puppet module in the Pupept code directory.
 # This allows us to make changes locally, outside of the VM then automatically available

--- a/build/ubuntu14-puppet5/Puppetfile
+++ b/build/ubuntu14-puppet5/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/ubuntu14-puppet6/Puppetfile
+++ b/build/ubuntu14-puppet6/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/ubuntu16-puppet5/Puppetfile
+++ b/build/ubuntu16-puppet5/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/build/ubuntu16-puppet6/Puppetfile
+++ b/build/ubuntu16-puppet6/Puppetfile
@@ -38,7 +38,6 @@
 #   │ ├── puppet-archive (v3.2.1)
 #   │ └── camptocamp-systemd (v2.3.0)
 #   ├── ghoneycutt-facter (v3.5.0)
-#   ├── computology-packagecloud (v0.3.2)
 #   ├── puppet-selinux (v1.6.1)
 #   ├── puppet-nginx (v0.16.0)
 #   └── puppet-nodejs (v7.0.0)
@@ -60,7 +59,6 @@ mod 'puppet-rabbitmq'
 mod 'puppet-archive'       # dependency of puppet-rabbitmq
 mod 'camptocamp-systemd'   # dependency of puppet-rabbitmq
 mod 'ghoneycutt-facter'
-mod 'computology-packagecloud'
 mod 'puppet-selinux'
 mod 'puppet-nginx'
 mod 'puppet-nodejs'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,8 @@
 #   Set the number of actionrunner processes to start
 # @param packs
 #   Hash of st2 packages to be installed
+# @param packs_group
+#   Name of the group that will own the /opt/stackstorm/packs directory (default: st2packs)
 # @param index_url
 #   Url to the StackStorm Exchange index file. (default undef)
 # @param mistral_db_host
@@ -242,6 +244,7 @@ class st2(
   $cli_auth_url             = "http://${::st2::params::hostname}:${::st2::params::auth_port}",
   $actionrunner_workers     = $::st2::params::actionrunner_workers,
   $packs                    = {},
+  $packs_group              = $::st2::params::packs_group_name,
   $index_url                = undef,
   $mistral_db_host          = $::st2::params::hostname,
   $mistral_db_name          = $::st2::params::mistral_db_name,

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -24,43 +24,6 @@ define st2::pack (
   include st2
   $_cli_username = $::st2::cli_username
   $_cli_password = $::st2::cli_password
-  $_st2_packs_group = $::st2::params::packs_group_name
-
-  ensure_resource('group', $_st2_packs_group, {
-    'ensure' => present,
-  })
-
-  ensure_resource('file', '/opt/stackstorm', {
-    'ensure' => 'directory',
-    'owner'  => 'root',
-    'group'  => 'root',
-    'mode'   => '0755',
-  })
-
-  ensure_resource('file', '/opt/stackstorm/packs', {
-    'ensure'  => 'directory',
-    'owner'   => 'root',
-    'group'   => $_st2_packs_group,
-    'recurse' => true,
-    'tag'     => 'st2::subdirs',
-  })
-
-  ensure_resource('file', '/opt/stackstorm/configs', {
-    'ensure'  => 'directory',
-    'owner'   => 'st2',
-    'group'   => 'root',
-    'mode'    => '0755',
-    'tag'     => 'st2::subdirs',
-  })
-
-  ensure_resource('file', '/opt/stackstorm/virtualenvs', {
-    'ensure'  => 'directory',
-    'owner'   => 'root',
-    'group'   => $_st2_packs_group,
-    'mode'    => '0755',
-    'tag'     => 'st2::subdirs',
-  })
-
 
   st2_pack { $pack:
     ensure   => $ensure,
@@ -85,10 +48,6 @@ define st2::pack (
     -> File["/opt/stackstorm/configs/${pack}.yaml"]
     ~> Exec<| tag == 'st2::register-configs' |>
   }
-
-  Group[$_st2_packs_group]
-  -> File['/opt/stackstorm']
-  -> File<| tag == 'st2::subdirs' |>
 
   Service<| tag == 'st2::service' |> -> St2_pack<||>
   Exec<| tag == 'st2::reload' |> -> St2_pack<||>

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,37 @@
+# manages the StackStorm repo
+class st2::repo (
+  Variant[Enum['present', 'absent'], Boolean] $ensure = 'present',
+  Enum['stable', 'unstable'] $repository              = 'stable',
+) {
+  case $facts['os']['family'] {
+    'RedHat', 'Linux': {
+      $dist_version = $facts['os']['release']['major']
+      $baseurl = "https://packagecloud.io/StackStorm/${repository}/el/${dist_version}/\$basearch"
+      $gpgkey = "https://packagecloud.io/StackStorm/${repository}/gpgkey"
+
+      contain st2::repo::yum
+    }
+
+    'Debian': {
+      # debian, ubuntu, etc
+      $osname = downcase($facts['os']['name'])
+      # trusty, xenial, bionic, etc
+      $release = downcase($facts['os']['distro']['codename'])
+      $location = "https://packagecloud.io/StackStorm/${repository}/${osname}"
+      $repos = 'main'
+
+      $key_id = $repository ? {
+        'stable'   => '3CE01873543A4CCE',
+        'unstable' => '1CDF3CE710B2CCF3',
+        default    => '3CE01873543A4CCE', # stable
+      }
+      $key_source = "https://packagecloud.io/StackStorm/${repository}/gpgkey"
+
+      contain st2::repo::apt
+    }
+
+    default: {
+      fail("Unsupported managed repository for osfamily: ${facts['os']['family']}, operatingsystem: ${facts['os']['name']}")
+    }
+  }
+}

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,0 +1,22 @@
+# Apt repo for StackStorm
+class st2::repo::apt {
+  if $st2::repo::ensure == 'present' or $st2::repo::ensure == true {
+    apt::source { "StackStorm_${st2::repo::repository}":
+      location => $st2::repo::location,
+      release  => $st2::repo::release,
+      repos    => $st2::repo::repos,
+      key      => {
+        'id'     => $st2::repo::key_id,
+        'source' => $st2::repo::key_server,
+      },
+    }
+
+    Apt::Source["StackStorm_${st2::repo::repository}"]
+    -> Package<| tag == 'st2::server::packages' |>
+  }
+  else {
+    apt::source { "StackStorm_${st2::repo::repository}":
+      ensure => absent,
+    }
+  }
+}

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -1,0 +1,20 @@
+# Yum repo for StackStorm
+class st2::repo::yum {
+  if $st2::repo::ensure == 'present' or $st2::repo::ensure == true {
+    yumrepo { "StackStorm_${st2::repo::repository}":
+      baseurl       => $st2::repo::baseurl,
+      enabled       => '1',
+      gpgcheck      => '0',
+      repo_gpgcheck => '1',
+      gpgkey        => $st2::repo::gpgkey,
+    }
+
+    Yumrepo["StackStorm_${st2::repo::repository}"]
+    -> Package<| tag == 'st2::server::packages' |>
+  }
+  else {
+    yumrepo { "StackStorm_${st2::repo::repository}":
+      ensure => absent,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "puppet/mongodb",
-      "version_requirement": ">= 0.14.0"
+      "version_requirement": ">= 3.1.0"
     },
     {
       "name": "puppetlabs/postgresql",
@@ -95,7 +95,7 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.14.1",
-  "template-url": "pdk-default#1.14.1",
-  "template-ref": "1.14.1-0-g0b5b39b"
+  "pdk-version": "1.16.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#1.16.0",
+  "template-ref": "tags/1.16.0-0-gaf44904"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -57,10 +57,6 @@
       "version_requirement": ">= 3.0.0"
     },
     {
-      "name": "computology/packagecloud",
-      "version_requirement": ">= 0.3.1"
-    },
-    {
       "name": "puppet/selinux",
       "version_requirement": ">= 0.5.0"
     },
@@ -71,6 +67,10 @@
     {
       "name": "puppet/nodejs",
       "version_requirement": ">= 1.3.0"
+    },
+    {
+      "name": "npwalker/recursive_file_permissions",
+      "version_requirement": ">= 0.6.0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,0 +1,14 @@
+---
+docker_centos6:
+  provisioner: docker
+  images: ['litmusimage/centos:6']
+docker_centos7:
+  provisioner: docker
+  images: ['litmusimage/centos:7']
+docker_ubuntu16:
+  provisioner: docker
+  images: ['litmusimage/ubuntu:16.04']
+docker_ubuntu18:
+  provisioner: docker
+  images: ['litmusimage/ubuntu:18.04']
+# TODO vagrant

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,14 +1,14 @@
 ---
 docker_centos6:
-  provisioner: docker
-  images: ['litmusimage/centos:6']
+  provisioner: docker_exp
+  images: ['stackstorm/packagingtest:centos6-sshd']
 docker_centos7:
-  provisioner: docker
-  images: ['litmusimage/centos:7']
+  provisioner: docker_exp
+  images: ['stackstorm/packagingtest:centos7-systemd']
 docker_ubuntu16:
-  provisioner: docker
-  images: ['litmusimage/ubuntu:16.04']
+  provisioner: docker_exp
+  images: ['stackstorm/packagingtest:xenial-systemd']
 docker_ubuntu18:
-  provisioner: docker
-  images: ['litmusimage/ubuntu:18.04']
+  provisioner: docker_exp
+  images: ['stackstorm/packagingtest:bionic-systemd']
 # TODO vagrant

--- a/spec/acceptance/01_apply_spec.rb
+++ b/spec/acceptance/01_apply_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper_acceptance'
+
+describe 'apply' do
+  context 'when full install' do
+    let(:pp) do
+      <<-MANIFEST
+        include st2::profile::fullinstall
+      MANIFEST
+    end
+
+    it 'applies the manifest twice with no stderr' do
+      idempotent_apply(pp)
+    end
+  end
+end

--- a/spec/acceptance/01_apply_spec.rb
+++ b/spec/acceptance/01_apply_spec.rb
@@ -4,7 +4,10 @@ describe 'apply' do
   context 'when full install' do
     let(:pp) do
       <<-MANIFEST
-        include st2::profile::fullinstall
+        class { 'sudo':
+          purge => false,
+        }
+        contain st2::profile::fullinstall
       MANIFEST
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |c|
   c.mock_with :rspec
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+require 'puppet_litmus'
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
+PuppetLitmus.configure!


### PR DESCRIPTION
The Puppet community has rallied around a new tool called Litmus to do integration testing along with the ServerSpec framework. This PR converts our Kitchen testing harness over to using Litmus and also converts the InSpec tests over to ServerSpec.

**TODO**
- [ ] Convert travis builds to Litmus
- [ ] Get all basic builds passing on current OSes
- [ ] Convert all InSpec tests to ServerSpec
- [ ] Setup Vagrant boxes in Litmus
- [ ] Remove Kitchen
- [ ] Remove InSpec