### PR TITLE
Fix bugs in st2::key_get and st2::key_decrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       before_install:
         - echo 'no bundler needed here'
       script:
-        - make
+        - make python2
     - name: "Unit Testing - Bolt Tasks Python 3.6"
       language: python
       python: 3.6
@@ -57,7 +57,7 @@ matrix:
       before_install:
         - echo 'no bundler needed here'
       script:
-        - make
+        - make python3
     - name: "Documentation Testing"
       rvm: 2.5
       # use default Gemfile in repo root (from PDK)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
 - Added Puppet Forge Endorsement badge to show that this is an Approved Puppet module. (Enhancement)
   Contributed by @nmaludy
 
+- Fixed bug in `st2::key_get` task where non-JSON output from the command would throw an 
+  exception. (Bugfix)
+  Contributed by @nmaludy
+  
+- Fixed bug in `st2::key_decrypt` causing it to be incompatible with Python 3. (Bugfix)
+  Contributed by @nmaludy
+
 ## 1.6.0 (Feb 17, 2020)
 
 - Updated to new Puppet style guide where the leading `::` in class names is no longer

--- a/tasks/key_decrypt.py
+++ b/tasks/key_decrypt.py
@@ -466,4 +466,4 @@ if __name__ == '__main__':
 
     # wrap in an object because otherwise Bolt won't parse the
     # JSON array into an array, if it's an object then it works
-    print json.dumps({'result': keys})
+    print(json.dumps({'result': keys}))

--- a/tasks/key_get.py
+++ b/tasks/key_get.py
@@ -12,7 +12,7 @@ class KeyGet(St2TaskBase):
 
     def convert_result_from_json(self, result, convert):
         # convert value from a JSON string to dict/list/etc
-        if convert and result.get('result', {}).get('value'):
+        if convert and 'result' in result and 'value' in result['result']:
             try:
                 result['result']['value'] = json.loads(result['result']['value'])
             except ValueError:

--- a/test/unit/test_tasks_key_get.py
+++ b/test/unit/test_tasks_key_get.py
@@ -45,6 +45,13 @@ class KeyGetTestCase(St2TestCase):
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': {'blah': 'xxx'}})
 
+    def test_convert_result_from_json_result_string_no_value(self):
+        res = {'result': 'string with non-json data'}
+        convert = True
+        task = KeyGet()
+        result = task.convert_result_from_json(res, convert)
+        self.assertEquals(result, {'result': 'string with non-json data'})
+
     def test_convert_result_from_json_no_result(self):
         res = {'value': '["a", "b", "c"]'}
         convert = True


### PR DESCRIPTION
Ran into two bugs:

1) `st2::key_decrypt` had an incompatible python3 statement.

2) `st2::key_get` had a bug in its logic when trying to parse the results. It always assumed a key existed in the dictionary, but if an error occurred the output might not be JSON so we need to handle this correctly.