### PR TITLE
Hard code locale so that st2 command is called with utf8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   
 - Fixed bug in `st2::key_decrypt` causing it to be incompatible with Python 3. (Bugfix)
   Contributed by @nmaludy
+  
+- Added an override for the `LC_ALL` environment variable in all Bolt tasks, so that the
+  locale is set to UTF-8, preventing a WARNING from being output from the `st2` command line.
+  Without this override, new versions of Bolt set the locale to `C` causing a warning and
+  preventing the JSON Output from the `st2` command from being parsed properly. (Bugfix)
+  Contributed by @nmaludy
 
 ## 1.6.0 (Feb 17, 2020)
 

--- a/files/st2_task_base.py
+++ b/files/st2_task_base.py
@@ -27,6 +27,9 @@ class St2TaskBase(TaskHelper):
         # inherit environment variables from the Bolt context to preserve things
         # like locale... otherwise we get errors from the StackStorm client.
         self.env = os.environ
+        # force the locale to UTF8, otherwise we get warnings from the stackstorm side
+        # and result in us not being able to parse JSON output
+        self.env['LC_ALL'] = 'en_US.UTF-8'
 
         # prefer API key over auth tokens
         if self.api_key:


### PR DESCRIPTION
Before this fix, new versions of bolt were running the tasks and getting an output like: 
```
2020-06-23 10:37:22,090  WARNING - Locale unknown with encoding ANSI_X3.4-1968 which is not UTF-8 is used. This means that some functionality which relies on outputting unicode characters won''t work. You are encouraged to use UTF-8 locale by setting LC_ALL environment variable to en_US.UTF-8 or similar.
```

When this warning was printed from the `st2` CLI it would cause the tasks to fail parsing the JSON output.

This fix sets the `LC_ALL` locale to be UTF-8 so that this warning isn't printing allowing JSON to be parsed correctly and tasks to succeed.