### PR TITLE
Add new tasks: st2::pack_register, st2::rule_disable, st2::rule_list, st2::run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@
   Without this override, new versions of Bolt set the locale to `C` causing a warning and
   preventing the JSON Output from the `st2` command from being parsed properly. (Bugfix)
   Contributed by @nmaludy
+  
+- Added new Bolt tasks:
+  - `st2::pack_register`: Registers a list of packs based from paths on the filesystem
+  - `st2::rule_disable`: Disables a rule
+  - `st2::rule_list`: Lists all rules, or just the rules in a given pack
+  - `st2::run`: Runs a StackStorm action
+  
+  (Enhancement)
+  Contributed by @nmaludy
 
 ## 1.6.0 (Feb 17, 2020)
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,11 @@ a node where StackStorm is installed.
 - `st2::key_load` - Loads a list of key/value pairs into the datastore
 - `st2::pack_install` - Installs a list of packs
 - `st2::pack_list` - Get a list of installed packs
+- `st2::pack_register`: Registers a list of packs based from paths on the filesystem
 - `st2::pack_remove` - Removes a list of packs
+- `st2::rule_disable`: Disables a rule
+- `st2::rule_list`: Lists all rules, or just the rules in a given pack
+- `st2::run`: Runs a StackStorm action
 
 #### Task Authentication
 

--- a/tasks/key_get.py
+++ b/tasks/key_get.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
 from st2_task_base import St2TaskBase
 
 
-class KeyGet(St2TaskBase):
+class St2KeyGet(St2TaskBase):
 
     def convert_result_from_json(self, result, convert):
         # convert value from a JSON string to dict/list/etc
@@ -39,4 +39,4 @@ class KeyGet(St2TaskBase):
 
 
 if __name__ == '__main__':
-    KeyGet().run()
+    St2KeyGet().run()

--- a/tasks/key_load.py
+++ b/tasks/key_load.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
 from st2_task_base import St2TaskBase
 
 
-class KeyLoad(St2TaskBase):
+class St2KeyLoad(St2TaskBase):
 
     def task_impl(self, args):
         temp_fd = None
@@ -37,4 +37,4 @@ class KeyLoad(St2TaskBase):
 
 
 if __name__ == '__main__':
-    KeyLoad().run()
+    St2KeyLoad().run()

--- a/tasks/pack_install.py
+++ b/tasks/pack_install.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
 from st2_task_base import St2TaskBase
 
 
-class PackInstall(St2TaskBase):
+class St2PackInstall(St2TaskBase):
 
     def task_impl(self, args):
         # install the list of packs
@@ -17,4 +17,4 @@ class PackInstall(St2TaskBase):
 
 
 if __name__ == '__main__':
-    PackInstall().run()
+    St2PackInstall().run()

--- a/tasks/pack_list.py
+++ b/tasks/pack_list.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
 from st2_task_base import St2TaskBase
 
 
-class PackList(St2TaskBase):
+class St2PackList(St2TaskBase):
 
     def task_impl(self, args):
         # get a list of packs
@@ -16,4 +16,4 @@ class PackList(St2TaskBase):
 
 
 if __name__ == '__main__':
-    PackList().run()
+    St2PackList().run()

--- a/tasks/pack_register.json
+++ b/tasks/pack_register.json
@@ -1,0 +1,37 @@
+{
+  "description": "Registers a pack that exists on the filesystem",
+  "parameters": {
+    "paths": {
+      "type": "Array[String]",
+      "description": "Array of directories on the local StackStorm filesystem where the pack contents currently exist and will be used to register from."
+    },
+    "api_key": {
+      "description": "StackStorm API key to use for authentication (prefer this over username/password).",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "auth_token": {
+      "description": "StackStorm auth token. Use this if username/password auth has already been established in a previous task and auth token is being passed around.",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "username": {
+      "description": "Username to use for StackStorm authentication.",
+      "type": "Optional[String]"
+    },
+    "password": {
+      "description": "Password to use for StackStorm authentication.",
+      "type": "Optional[String]",
+      "sensitive": true
+    }
+  },
+  "implementations": [
+    {
+      "name": "pack_register.py",
+      "files": [
+        "python_task_helper/files/task_helper.py",
+        "st2/files/st2_task_base.py"
+      ]
+    }
+  ]
+}

--- a/tasks/pack_register.py
+++ b/tasks/pack_register.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import os
+import sys
+
+# import Bolt task helper
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
+from st2_task_base import St2TaskBase
+
+
+class St2PackRegister(St2TaskBase):
+
+    def task_impl(self, args):
+        # register a list of packs based on a paths on the filesystem
+        paths = args['paths']
+        cmd = ['st2', 'pack', 'register', '--json'] + paths
+        return self.exec_cmd(cmd, 'register packs')
+
+
+if __name__ == '__main__':
+    St2PackRegister().run()

--- a/tasks/rule_disable.json
+++ b/tasks/rule_disable.json
@@ -1,0 +1,37 @@
+{
+  "description": "Disable a given rule",
+  "parameters": {
+    "rule": {
+      "type": "String",
+      "description": "Name of a rule to disable (format: pack_name.rule_name)"
+    },
+    "api_key": {
+      "description": "StackStorm API key to use for authentication (prefer this over username/password).",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "auth_token": {
+      "description": "StackStorm auth token. Use this if username/password auth has already been established in a previous task and auth token is being passed around.",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "username": {
+      "description": "Username to use for StackStorm authentication.",
+      "type": "Optional[String]"
+    },
+    "password": {
+      "description": "Password to use for StackStorm authentication.",
+      "type": "Optional[String]",
+      "sensitive": true
+    }
+  },
+  "implementations": [
+    {
+      "name": "rule_disable.py",
+      "files": [
+        "python_task_helper/files/task_helper.py",
+        "st2/files/st2_task_base.py"
+      ]
+    }
+  ]
+}

--- a/tasks/rule_disable.py
+++ b/tasks/rule_disable.py
@@ -7,14 +7,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
 from st2_task_base import St2TaskBase
 
 
-class St2PackRemove(St2TaskBase):
+class St2RuleDisable(St2TaskBase):
 
     def task_impl(self, args):
-        # remove the list of packs
-        packs = args['packs']
-        cmd = ['st2', 'pack', 'remove', '--json'] + packs
-        return self.exec_cmd(cmd, 'remove packs')
+        # Disable the specified rule
+        rule = args['rule']
+        cmd = ['st2', 'rule', 'disable', '--json', rule]
+        return self.exec_cmd(cmd, 'disable pack rules')
 
 
 if __name__ == '__main__':
-    St2PackRemove().run()
+    St2RuleDisable().run()

--- a/tasks/rule_list.json
+++ b/tasks/rule_list.json
@@ -1,0 +1,37 @@
+{
+  "description": "Return a list of rules.",
+  "parameters": {
+    "pack": {
+      "type": "Optional[String]",
+      "description": "Name of a pack if you want to return rules only for a given pack."
+    },
+    "api_key": {
+      "description": "StackStorm API key to use for authentication (prefer this over username/password).",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "auth_token": {
+      "description": "StackStorm auth token. Use this if username/password auth has already been established in a previous task and auth token is being passed around.",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "username": {
+      "description": "Username to use for StackStorm authentication.",
+      "type": "Optional[String]"
+    },
+    "password": {
+      "description": "Password to use for StackStorm authentication.",
+      "type": "Optional[String]",
+      "sensitive": true
+    }
+  },
+  "implementations": [
+    {
+      "name": "rule_list.py",
+      "files": [
+        "python_task_helper/files/task_helper.py",
+        "st2/files/st2_task_base.py"
+      ]
+    }
+  ]
+}

--- a/tasks/rule_list.py
+++ b/tasks/rule_list.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+import sys
+
+# import Bolt task helper
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
+from st2_task_base import St2TaskBase
+
+
+class St2RuleList(St2TaskBase):
+
+    def task_impl(self, args):
+        cmd = ['st2', 'rule', 'list', '--json']
+
+        # add in pack argument if it was passed
+        pack = args.get('pack', None)
+        if pack:
+            cmd += ['--pack', pack]
+        return self.exec_cmd(cmd, 'list rules')
+
+
+if __name__ == '__main__':
+    St2RuleList().run()

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -1,0 +1,41 @@
+{
+  "description": "Runs a StackStorm action",
+  "parameters": {
+    "action": {
+      "type": "String",
+      "description": "Name of the action to execute"
+    },
+    "parameters": {
+      "description": "Array of parameter strings to pass to the execution. Named arguments should be of the format 'param=value' positional parameters can be put in their normal order as strings.",
+      "type": "Optional[Array[String]]"
+    },
+    "api_key": {
+      "description": "StackStorm API key to use for authentication (prefer this over username/password).",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "auth_token": {
+      "description": "StackStorm auth token. Use this if username/password auth has already been established in a previous task and auth token is being passed around.",
+      "type": "Optional[String]",
+      "sensitive": true
+    },
+    "username": {
+      "description": "Username to use for StackStorm authentication.",
+      "type": "Optional[String]"
+    },
+    "password": {
+      "description": "Password to use for StackStorm authentication.",
+      "type": "Optional[String]",
+      "sensitive": true
+    }
+  },
+  "implementations": [
+    {
+      "name": "run.py",
+      "files": [
+        "python_task_helper/files/task_helper.py",
+        "st2/files/st2_task_base.py"
+      ]
+    }
+  ]
+}

--- a/tasks/run.py
+++ b/tasks/run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import os
+import sys
+
+# import Bolt task helper
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'files'))
+from st2_task_base import St2TaskBase
+
+
+class St2Run(St2TaskBase):
+
+    def task_impl(self, args):
+        # Run a StackStorm action
+        action = args['action']
+        cmd = ['st2', 'run', '--json', action]
+
+        # add in parametrs if they were passed
+        parameters = args.get('parameters', None)
+        if parameters:
+            cmd += parameters
+        return self.exec_cmd(cmd, 'run action')
+
+
+if __name__ == '__main__':
+    St2Run().run()

--- a/test/unit/test_tasks_key_get.py
+++ b/test/unit/test_tasks_key_get.py
@@ -7,59 +7,59 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from key_get import KeyGet
+from key_get import St2KeyGet
 
 
-class KeyGetTestCase(St2TestCase):
+class St2KeyGetTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = KeyGet()
+        task = St2KeyGet()
         self.assertIsInstance(task, St2TaskBase)
 
     def test_convert_result_from_json(self):
         res = {'result': {'value': '{"a": "b"}'}}
         convert = True
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': {'value': {"a": "b"}}})
 
     def test_convert_result_from_json_false(self):
         res = {'result': {'value': '{"a": "b"}'}}
         convert = False
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': {'value': '{"a": "b"}'}})
 
     def test_convert_result_from_json_invalid_json(self):
         res = {'result': {'value': '{"a": "b'}}
         convert = True
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': {'value': '{"a": "b'}})
 
     def test_convert_result_from_json_no_value(self):
         res = {'result': {'blah': 'xxx'}}
         convert = True
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': {'blah': 'xxx'}})
 
     def test_convert_result_from_json_result_string_no_value(self):
         res = {'result': 'string with non-json data'}
         convert = True
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'result': 'string with non-json data'})
 
     def test_convert_result_from_json_no_result(self):
         res = {'value': '["a", "b", "c"]'}
         convert = True
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.convert_result_from_json(res, convert)
         self.assertEquals(result, {'value': '["a", "b", "c"]'})
 
-    @mock.patch('key_get.KeyGet.exec_cmd')
+    @mock.patch('key_get.St2KeyGet.exec_cmd')
     def test_task_impl(self, mock_exec_cmd):
         args = {
             'key': 'test_key',
@@ -67,7 +67,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.task(args)
 
         # assert
@@ -75,7 +75,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.assert_called_with(['st2', 'key', 'get', '--json', 'test_key'],
                                          'get key')
 
-    @mock.patch('key_get.KeyGet.exec_cmd')
+    @mock.patch('key_get.St2KeyGet.exec_cmd')
     def test_task_impl_scope(self, mock_exec_cmd):
         args = {
             'key': 'test_key',
@@ -84,7 +84,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.task(args)
 
         # assert
@@ -93,7 +93,7 @@ class KeyGetTestCase(St2TestCase):
                                           'test_key'],
                                          'get key')
 
-    @mock.patch('key_get.KeyGet.exec_cmd')
+    @mock.patch('key_get.St2KeyGet.exec_cmd')
     def test_task_impl_decrypt(self, mock_exec_cmd):
         args = {
             'key': 'test_key',
@@ -102,7 +102,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.task(args)
 
         # assert
@@ -110,7 +110,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.assert_called_with(['st2', 'key', 'get', '--json', 'test_key'],
                                          'get key')
 
-    @mock.patch('key_get.KeyGet.exec_cmd')
+    @mock.patch('key_get.St2KeyGet.exec_cmd')
     def test_task_impl_convert(self, mock_exec_cmd):
         args = {
             'key': 'test_key',
@@ -119,7 +119,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': '["a", "b", "c"]'}}
 
         # run
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.task(args)
 
         # assert
@@ -127,7 +127,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.assert_called_with(['st2', 'key', 'get', '--json', 'test_key'],
                                          'get key')
 
-    @mock.patch('key_get.KeyGet.exec_cmd')
+    @mock.patch('key_get.St2KeyGet.exec_cmd')
     def test_task_impl_convert_false(self, mock_exec_cmd):
         args = {
             'key': 'test_key',
@@ -136,7 +136,7 @@ class KeyGetTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': '["a", "b", "c"]'}}
 
         # run
-        task = KeyGet()
+        task = St2KeyGet()
         result = task.task(args)
 
         # assert

--- a/test/unit/test_tasks_key_load.py
+++ b/test/unit/test_tasks_key_load.py
@@ -7,20 +7,20 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from key_load import KeyLoad
+from key_load import St2KeyLoad
 
 
-class KeyLoadTestCase(St2TestCase):
+class St2KeyLoadTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = KeyLoad()
+        task = St2KeyLoad()
         self.assertIsInstance(task, St2TaskBase)
 
     @mock.patch('os.remove')
     @mock.patch('os.fdopen')
     @mock.patch('tempfile.mkstemp')
-    @mock.patch('key_load.KeyLoad.exec_cmd')
+    @mock.patch('key_load.St2KeyLoad.exec_cmd')
     def test_task_impl(self, mock_exec_cmd, mock_mkstemp, mock_fdopen, mock_remove):
         args = {
             'keys': [
@@ -42,7 +42,7 @@ class KeyLoadTestCase(St2TestCase):
         mock_fdopen.return_value = mock_context_manager
         mock_exec_cmd.return_value = 'expected'
 
-        task = KeyLoad()
+        task = St2KeyLoad()
         result = task.task(args)
 
         self.assertEquals(result, 'expected')
@@ -56,7 +56,7 @@ class KeyLoadTestCase(St2TestCase):
     @mock.patch('os.remove')
     @mock.patch('os.fdopen')
     @mock.patch('tempfile.mkstemp')
-    @mock.patch('key_load.KeyLoad.exec_cmd')
+    @mock.patch('key_load.St2KeyLoad.exec_cmd')
     def test_task_impl_convert(self, mock_exec_cmd, mock_mkstemp, mock_fdopen, mock_remove):
         args = {
             'keys': [
@@ -79,7 +79,7 @@ class KeyLoadTestCase(St2TestCase):
         mock_fdopen.return_value = mock_context_manager
         mock_exec_cmd.return_value = 'expected'
 
-        task = KeyLoad()
+        task = St2KeyLoad()
         result = task.task(args)
 
         self.assertEquals(result, 'expected')

--- a/test/unit/test_tasks_pack_install.py
+++ b/test/unit/test_tasks_pack_install.py
@@ -7,17 +7,17 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from pack_install import PackInstall
+from pack_install import St2PackInstall
 
 
-class PackInstallTestCase(St2TestCase):
+class St2PackInstallTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = PackInstall()
+        task = St2PackInstall()
         self.assertIsInstance(task, St2TaskBase)
 
-    @mock.patch('pack_install.PackInstall.exec_cmd')
+    @mock.patch('pack_install.St2PackInstall.exec_cmd')
     def test_task_impl(self, mock_exec_cmd):
         args = {
             'packs': ['pack1', 'pack2'],
@@ -25,7 +25,7 @@ class PackInstallTestCase(St2TestCase):
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = PackInstall()
+        task = St2PackInstall()
         result = task.task(args)
 
         # assert

--- a/test/unit/test_tasks_pack_list.py
+++ b/test/unit/test_tasks_pack_list.py
@@ -7,23 +7,23 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from pack_list import PackList
+from pack_list import St2PackList
 
 
-class PackListTestCase(St2TestCase):
+class St2PackListTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = PackList()
+        task = St2PackList()
         self.assertIsInstance(task, St2TaskBase)
 
-    @mock.patch('pack_list.PackList.exec_cmd')
+    @mock.patch('pack_list.St2PackList.exec_cmd')
     def test_task_impl(self, mock_exec_cmd):
         args = {}
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = PackList()
+        task = St2PackList()
         result = task.task(args)
 
         # assert

--- a/test/unit/test_tasks_pack_register.py
+++ b/test/unit/test_tasks_pack_register.py
@@ -7,28 +7,29 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from pack_remove import St2PackRemove
+from pack_register import St2PackRegister
 
 
-class St2PackRemoveTestCase(St2TestCase):
+class St2PackRegisterTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = St2PackRemove()
+        task = St2PackRegister()
         self.assertIsInstance(task, St2TaskBase)
 
-    @mock.patch('pack_remove.St2PackRemove.exec_cmd')
+    @mock.patch('pack_register.St2PackRegister.exec_cmd')
     def test_task_impl(self, mock_exec_cmd):
         args = {
-            'packs': ['pack1', 'pack2'],
+            'paths': ['/home/user/pack1', '/home/blah/pack2'],
         }
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = St2PackRemove()
+        task = St2PackRegister()
         result = task.task(args)
 
         # assert
         self.assertEquals(result, {'result': {'value': 'expected'}})
-        mock_exec_cmd.assert_called_with(['st2', 'pack', 'remove', '--json', 'pack1', 'pack2'],
-                                         'remove packs')
+        mock_exec_cmd.assert_called_with(['st2', 'pack', 'register', '--json',
+                                          '/home/user/pack1', '/home/blah/pack2'],
+                                         'register packs')

--- a/test/unit/test_tasks_rule_disable.py
+++ b/test/unit/test_tasks_rule_disable.py
@@ -7,28 +7,28 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
 from st2_task_base import St2TaskBase
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
-from pack_remove import St2PackRemove
+from rule_disable import St2RuleDisable
 
 
-class St2PackRemoveTestCase(St2TestCase):
+class St2RuleDisableTestCase(St2TestCase):
     __test__ = True
 
     def test_init(self):
-        task = St2PackRemove()
+        task = St2RuleDisable()
         self.assertIsInstance(task, St2TaskBase)
 
-    @mock.patch('pack_remove.St2PackRemove.exec_cmd')
+    @mock.patch('rule_disable.St2RuleDisable.exec_cmd')
     def test_task_impl(self, mock_exec_cmd):
         args = {
-            'packs': ['pack1', 'pack2'],
+            'rule': 'rule1',
         }
         mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
 
         # run
-        task = St2PackRemove()
+        task = St2RuleDisable()
         result = task.task(args)
 
         # assert
         self.assertEquals(result, {'result': {'value': 'expected'}})
-        mock_exec_cmd.assert_called_with(['st2', 'pack', 'remove', '--json', 'pack1', 'pack2'],
-                                         'remove packs')
+        mock_exec_cmd.assert_called_with(['st2', 'rule', 'disable', '--json', 'rule1'],
+                                         'disable pack rules')

--- a/test/unit/test_tasks_rule_list.py
+++ b/test/unit/test_tasks_rule_list.py
@@ -1,0 +1,48 @@
+from test.unit.st2_test_case import St2TestCase
+import mock
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
+from st2_task_base import St2TaskBase
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
+from rule_list import St2RuleList
+
+
+class St2RuleListTestCase(St2TestCase):
+    __test__ = True
+
+    def test_init(self):
+        task = St2RuleList()
+        self.assertIsInstance(task, St2TaskBase)
+
+    @mock.patch('rule_list.St2RuleList.exec_cmd')
+    def test_task_impl(self, mock_exec_cmd):
+        args = {}
+        mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
+
+        # run
+        task = St2RuleList()
+        result = task.task(args)
+
+        # assert
+        self.assertEquals(result, {'result': {'value': 'expected'}})
+        mock_exec_cmd.assert_called_with(['st2', 'rule', 'list', '--json'],
+                                         'list rules')
+
+    @mock.patch('rule_list.St2RuleList.exec_cmd')
+    def test_task_impl_with_pack(self, mock_exec_cmd):
+        args = {
+            'pack': 'pack1',
+        }
+        mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
+
+        # run
+        task = St2RuleList()
+        result = task.task(args)
+
+        # assert
+        self.assertEquals(result, {'result': {'value': 'expected'}})
+        mock_exec_cmd.assert_called_with(['st2', 'rule', 'list', '--json', '--pack', 'pack1'],
+                                         'list rules')

--- a/test/unit/test_tasks_run.py
+++ b/test/unit/test_tasks_run.py
@@ -1,0 +1,59 @@
+from test.unit.st2_test_case import St2TestCase
+import mock
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'files'))
+from st2_task_base import St2TaskBase
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'tasks'))
+from run import St2Run
+
+
+class St2RunTestCase(St2TestCase):
+    __test__ = True
+
+    def test_init(self):
+        task = St2Run()
+        self.assertIsInstance(task, St2TaskBase)
+
+    @mock.patch('run.St2Run.exec_cmd')
+    def test_task_impl(self, mock_exec_cmd):
+        args = {
+            'action': 'pack1.action2',
+        }
+        mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
+
+        # run
+        task = St2Run()
+        result = task.task(args)
+
+        # assert
+        self.assertEquals(result, {'result': {'value': 'expected'}})
+        mock_exec_cmd.assert_called_with(['st2', 'run', '--json', 'pack1.action2'],
+                                         'run action')
+
+    @mock.patch('run.St2Run.exec_cmd')
+    def test_task_impl_with_parameters(self, mock_exec_cmd):
+        args = {
+            'action': 'pack1.action2',
+            'parameters': [
+                'cmd=date',
+                'param2=value2',
+                # this is how you pass a dict/object
+                'param_dict={"key": "value"}',
+            ],
+        }
+        mock_exec_cmd.return_value = {'result': {'value': 'expected'}}
+
+        # run
+        task = St2Run()
+        result = task.task(args)
+
+        # assert
+        self.assertEquals(result, {'result': {'value': 'expected'}})
+        mock_exec_cmd.assert_called_with(['st2', 'run', '--json', 'pack1.action2',
+                                          'cmd=date',
+                                          'param2=value2',
+                                          'param_dict={"key": "value"}'],
+                                         'run action')


### PR DESCRIPTION
We were maintaining a few st2 tasks in a private fork for no good reason. This PR migrates those tasks to the open source version so everyone can benefit.