### PR TITLE
Replace stahnma-epel with puppet-epel

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
     stdlib: "puppetlabs/stdlib"
     staging: "puppet/staging"
     apt: "puppetlabs/apt"
-    epel: "stahnma/epel"
+    epel: "puppet/epel"
     concat: "puppetlabs/concat"
     sudo: "saz/sudo"
     python: "puppet/python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
   
   (Enhancement)
   Contributed by @nmaludy
+  
+- Replaced deprecated `stahnma-epel` module with `puppet-epel`. (Enhancement)
+  Contributed by @nmaludy
 
 ## 1.6.0 (Feb 17, 2020)
 

--- a/build/centos6-puppet5/Puppetfile
+++ b/build/centos6-puppet5/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/centos6-puppet6/Puppetfile
+++ b/build/centos6-puppet6/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/centos7-puppet5/Puppetfile
+++ b/build/centos7-puppet5/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/centos7-puppet6/Puppetfile
+++ b/build/centos7-puppet6/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu14-puppet5/Puppetfile
+++ b/build/ubuntu14-puppet5/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu14-puppet6/Puppetfile
+++ b/build/ubuntu14-puppet6/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu16-puppet5/Puppetfile
+++ b/build/ubuntu16-puppet5/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu16-puppet6/Puppetfile
+++ b/build/ubuntu16-puppet6/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu18-puppet5/Puppetfile
+++ b/build/ubuntu18-puppet5/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/build/ubuntu18-puppet6/Puppetfile
+++ b/build/ubuntu18-puppet6/Puppetfile
@@ -28,7 +28,7 @@
 #   │ └── puppetlabs-translate (v1.2.0)
 #   ├── saz-sudo (v6.0.0)
 #   ├─┬ puppet-python (v2.2.2)
-#   │ └── stahnma-epel (v1.3.1)
+#   │ └── puppet-epel (v1.3.1)
 #   ├── puppetlabs-inifile (v2.5.0)
 #   ├── puppet-mongodb (v2.4.1)
 #   ├─┬ puppetlabs-postgresql (v5.12.1)
@@ -45,7 +45,7 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'jamtur01-httpauth'
 mod 'puppetlabs-apt'
-mod 'stahnma-epel'
+mod 'puppet-epel'
 mod 'puppetlabs-translate' # dependency of puppetlabs-apt
 mod 'saz-sudo'
 mod 'puppet-python'

--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,8 @@
       "version_requirement": ">= 1.7.0 < 8.0.0"
     },
     {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.1.0 < 2.0.0"
+      "name": "puppet/epel",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "saz/sudo",


### PR DESCRIPTION
Prepping for the 1.7.0 release.

The stahnma-epel repo is deprecated and has been replaced with puppet-epel. This migrates to the new module.
