### PR TITLE
Enable travis to deploy the module to the forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,17 @@ branches:
 # all and if one fails it will ignore the failure and go onto the next
 script:
   - build/scripts/ci.sh
-  
-matrix:
+
+stages:
+  - test
+  - if: tag =~ ^v\d
+    name: deploy
+      
+jobs:
   fast_finish: true
   include:
     - name: "Unit Testing - Puppet 5"
+      stage: test
       rvm: 2.4
       # use default Gemfile in repo root (from PDK)
       env:
@@ -36,6 +42,7 @@ matrix:
         - PUPPET_GEM_VERSION="~> 5.0"
         - CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop parallel_spec"
     - name: "Unit Testing - Puppet 6"
+      stage: test
       rvm: 2.5
       # use default Gemfile in repo root (from PDK)
       env:
@@ -43,6 +50,7 @@ matrix:
         - PUPPET_GEM_VERSION="~> 6.0"
         - CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop parallel_spec"
     - name: "Unit Testing - Bolt Tasks Python 2.7"
+      stage: test
       language: python
       python: 2.7
       cache: pip
@@ -51,6 +59,7 @@ matrix:
       script:
         - make python2
     - name: "Unit Testing - Bolt Tasks Python 3.6"
+      stage: test
       language: python
       python: 3.6
       cache: pip
@@ -59,51 +68,63 @@ matrix:
       script:
         - make python3
     - name: "Documentation Testing"
+      stage: test
       rvm: 2.5
       # use default Gemfile in repo root (from PDK)
       env:
         - DOCS_TEST="true"
         - PUPPET_GEM_VERSION="~> 6.0"
     - name: "RHEL/CentOS 6 - Puppet 5"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="centos6-puppet5"
     - name: "RHEL/CentOS 6 - Puppet 6"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="centos6-puppet6"
     - name: "RHEL/CentOS 7 - Puppet 5"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="centos7-puppet5"
     - name: "RHEL/CentOS 7 - Puppet 6"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="centos7-puppet6"
     - name: "Ubuntu 16 - Puppet 5"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="ubuntu16-puppet5"
     - name: "Ubuntu 16 - Puppet 6"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="ubuntu16-puppet6"
     - name: "Ubuntu 18 - Puppet 5"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="ubuntu18-puppet5"
     - name: "Ubuntu 18 - Puppet 6"
+      stage: test
       rvm: 2.5
       gemfile: build/kitchen/Gemfile
       env:
         - TEST_NAME="ubuntu18-puppet6"
+    - name: "Deploy to Forge"
+      stage: deploy
+      env: DEPLOY_TO_FORGE=yes
 
 notifications:
   # Post build failures to '#puppet' channel in 'stackstorm-community' Slack
@@ -114,3 +135,13 @@ notifications:
     on_success: change # default: always
     on_failure: always # default: always
 
+# deploy to forge when tagged with a new release
+deploy:
+  provider: puppetforge
+  username: stackstorm
+  password:
+    secure: "Em3vLHZA/asZiNHN5FO9DQAGLaQYEn9zCoDrkcOJUROFViY8luFvJ6necCnFQEGtC3kHXwoFpD05oCOxeVDm8NNzIbjFKPT7B4/wBndshp4pataxQNgnz8zw3Jufgih8p7nxf/ikugUiQKOiqKlp2U6QEGi5oVEQ5UpKx8KvhNg="
+  on:
+    tags: true
+    all_branches: true
+    condition: "$DEPLOY_TO_FORGE = yes"


### PR DESCRIPTION
Closes #241 

Enables the Travis deploy feature to automatically upload modules to the forge. This is triggered by a release tag on the repo.