### PR TITLE
Switch travis to using bionic as its base OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
-sudo: false
-dist: trusty
+os: linux
+dist: bionic
 services: docker
 language: ruby
 cache: bundler


### PR DESCRIPTION
- Switch travis to using bionic as its base OS
- Remove the deprecated `sudo` key (causes a warning)
- Set the `os: linux` key so we don't get a notice in Travis.