### PR TITLE
Correct logging config for api, auth and stream to point at gunicorn config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Drop support for CentOS 6 #304 (Enhancement)
   Contributed by @nmaludy
+  
+- Corrected `logging` setting for `api`, `auth` and `stream` to point at the 
+  `/etc/st2/logging.<service>.gunicorn.conf` logging config files, the current default. (Bugfix)
+  Contributed by @nmaludy
 
 ## 1.7.0 (Jun 26, 2020)
 

--- a/manifests/profile/server.pp
+++ b/manifests/profile/server.pp
@@ -199,7 +199,7 @@ class st2::profile::server (
     path    => $conf_file,
     section => 'api',
     setting => 'logging',
-    value   => "/etc/st2/${_logger_config}.api.conf",
+    value   => "/etc/st2/${_logger_config}.api.gunicorn.conf",
     tag     => 'st2::config',
   }
 
@@ -233,7 +233,7 @@ class st2::profile::server (
     path    => $conf_file,
     section => 'auth',
     setting => 'logging',
-    value   => "/etc/st2/${_logger_config}.auth.conf",
+    value   => "/etc/st2/${_logger_config}.auth.gunicorn.conf",
     tag     => 'st2::config',
   }
 
@@ -316,6 +316,16 @@ class st2::profile::server (
     section => 'sensorcontainer',
     setting => 'logging',
     value   => "/etc/st2/${_logger_config}.sensorcontainer.conf",
+    tag     => 'st2::config',
+  }
+
+  ## Stream Settings
+  ini_setting { 'stream_logging':
+    ensure  => present,
+    path    => $conf_file,
+    section => 'stream',
+    setting => 'logging',
+    value   => "/etc/st2/${_logger_config}.stream.gunicorn.conf",
     tag     => 'st2::config',
   }
 


### PR DESCRIPTION
I noticed this morning that there was a new default logging config in /etc/st2/st2.conf default... although this isn't reflected in https://github.com/StackStorm/st2/blob/master/conf/st2.conf.sample.

The new logging configs for `api`, `auth` and `stream` are `/etc/st2/logging.<service>.gunicorn.conf` 

This changes reflects the new default to match one-line installer.