### PR TITLE
Enable HSTS header for SSL server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Added `Strict-Transport-Security' SSL header (HSTS) and set max-age to 1 year for nginx server
+  resource. This will force browsers to always use https connections to the server.
+  Contributed by @paxri01
+
 - Fixed issue with upgrade mongodb bolt plan to handle passwords with special characters. (Bugfix)
   Contributed by @bishopbm
 

--- a/manifests/profile/web.pp
+++ b/manifests/profile/web.pp
@@ -107,8 +107,9 @@ class st2::profile::web(
 
   # http redirect to https
   $add_header = {
-    'Front-End-Https'        => 'on',
-    'X-Content-Type-Options' => 'nosniff',
+    'Front-End-Https'           => 'on',
+    'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+    'X-Content-Type-Options'    => 'nosniff',
   }
   nginx::resource::server { 'st2webui':
     ensure       => present,

--- a/spec/classes/profile/web_spec.rb
+++ b/spec/classes/profile/web_spec.rb
@@ -7,6 +7,7 @@ describe 'st2::profile::web' do
     let(:add_header) do
       {
         'Front-End-Https' => 'on',
+        'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
         'X-Content-Type-Options' => 'nosniff',
       }
     end


### PR DESCRIPTION
This change adds the 'Strict-Transport-Security' header to the nginx server statements.
It also sets the max-age timeout to 31536000 seconds (1 year) and includes subdomains.