### PR TITLE
Remove tags from system package dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-- Removed tags for auth system development dependencies (PAM and LDAP) that caused isseus
+- Removed tags for auth system development dependencies (PAM and LDAP) that caused issues
   when declaring packages such as `gcc`. (Bug Fix)
   Contributed by @nmaludy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+- Removed tags for auth system development dependencies (PAM and LDAP) that caused isseus
+  when declaring packages such as `gcc`. (Bug Fix)
+  Contributed by @nmaludy
+
 - Added `Strict-Transport-Security' SSL header (HSTS) and set max-age to 1 year for nginx server
   resource. This will force browsers to always use https connections to the server.
   Contributed by @paxri01

--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -141,7 +141,6 @@ class st2::auth::ldap (
   ensure_packages($_dep_pkgs,
                   {
                     'ensure' => 'present',
-                    'tag'    => 'st2::auth::ldap',
                   })
 
   # install the backend package

--- a/manifests/auth/pam.pp
+++ b/manifests/auth/pam.pp
@@ -49,7 +49,6 @@ class st2::auth::pam(
   ensure_packages($_dep_pkgs,
                   {
                     'ensure' => 'present',
-                    'tag'    => 'st2::auth::ldap',
                   })
 
   # install the backend package


### PR DESCRIPTION
Previously the system dependencies for the auth packages had tags declared. These tags were not used. It caused issues with things such as `gcc` when other modules would try to declare these packages, the declarations would conflict because the `Package[gcc]` declaration in the other modules wouldn't include the StackStorm tags.

Since these tags are unused, i simply removed them!