### PR TITLE
Fix failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Development
 
+- Removed `manage_virtualenv_package` in Python profile to fix integration tests. Contributed by @rush-skills
+
 ## 2.1.0 (Mar 6, 2021)
   Note: This version only supports the 'integrated' LDAP plugin.
 

--- a/manifests/profile/python.pp
+++ b/manifests/profile/python.pp
@@ -49,10 +49,9 @@ class st2::profile::python (
 
     # intall python and python-devel / python-dev
     class { 'python':
-      version                   => $version,
-      dev                       => present,
-      manage_pip_package        => false,
-      manage_virtualenv_package => false,
+      version            => $version,
+      dev                => present,
+      manage_pip_package => false,
     }
   }
 }


### PR DESCRIPTION
Currently the puppet-st2 builds are failing due to an error in the `st2::profiles::python` with the following error in all integrations tests.

> Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Python]: has no parameter named 'manage_virtualenv_package' (file: /tmp/kitchen/modules/st2/manifests/profile/python.pp, line: 51, column: 5)

By removing `manage_virtualenv_package` parameter for python class, the error is fixed and the tests are green again