### PR TITLE
LDAP auth: Add cacert parameter and use hash to_json instead of a template

### DIFF
--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -86,6 +86,7 @@ class st2::auth::ldap (
   $id_attr         = 'uid',
   $account_pattern = '',
   $group_pattern   = '',
+  $group_dns_check = 'and',
 ) inherits st2 {
   include st2::auth::common
 
@@ -104,6 +105,7 @@ class st2::auth::ldap (
     'id_attr'         => $id_attr,
     'account_pattern' => $account_pattern,
     'group_pattern'   => $group_pattern,
+    'group_dns_check' => $group_dns_check,
   }
 
   $_kwargs = to_json($backend_kwargs_raw)

--- a/manifests/auth/ldap.pp
+++ b/manifests/auth/ldap.pp
@@ -65,7 +65,7 @@
 #    chase_referrals: false
 #    base_dn: 'dc=domain,dc=tld'
 #    group_dns:
-#      - '"cn=stackstorm_users,ou=groups,dc=domain,dc=tld"'
+#      - 'cn=stackstorm_users,ou=groups,dc=domain,dc=tld'
 #    scope: "subtree"
 #    id_attr: "username"
 #    account_pattern: "userPrincipalName={username}"
@@ -75,6 +75,7 @@ class st2::auth::ldap (
   $host            = '',
   $use_tls         = false,
   $use_ssl         = false,
+  $cacert          = '',
   $port            = 389,
   $bind_dn         = '',
   $bind_pw         = '',
@@ -83,53 +84,29 @@ class st2::auth::ldap (
   $chase_referrals = true,
   $scope           = 'subtree',
   $id_attr         = 'uid',
-  $account_pattern = undef,
-  $group_pattern   = undef,
+  $account_pattern = '',
+  $group_pattern   = '',
 ) inherits st2 {
   include st2::auth::common
 
-  $_use_tls = bool2str($use_tls)
-  $_use_ssl = bool2str($use_ssl)
-  $_chase_refs = bool2str($chase_referrals)
-  if $account_pattern != undef and $group_pattern != undef {
-    $_kwargs = @("LDAPARGS"/L)
-      {"host": "${host}", "use_tls": ${_use_tls},\
-      "bind_dn": "${bind_dn}", "bind_password": "${bind_pw}",\
-      "chase_referrals": ${_chase_refs}, "base_ou": "${base_dn}",\
-      "group_dns": ${group_dns}, "use_ssl": ${_use_ssl}, "port": ${port},\
-      "scope": "${scope}", "id_attr": "${id_attr}",\
-      "account_pattern": "${account_pattern}", "group_pattern": "${group_pattern}"}
-      | - LDAPARGS
+  $backend_kwargs_raw = {
+    'host'            => $host,
+    'use_tls'         => $use_tls,
+    'use_ssl'         => $use_ssl,
+    'cacert'          => $cacert,
+    'port'            => $port,
+    'bind_dn'         => $bind_dn,
+    'bind_password'   => $bind_pw,
+    'base_ou'         => $base_dn,
+    'group_dns'       => $group_dns,
+    'chase_referrals' => $chase_refs,
+    'scope'           => $scope,
+    'id_attr'         => $id_attr,
+    'account_pattern' => $account_pattern,
+    'group_pattern'   => $group_pattern,
   }
-  elsif $account_pattern != undef {
-    $_kwargs = @("LDAPARGS"/L)
-      {"host": "${host}", "use_tls": ${_use_tls},\
-      "bind_dn": "${bind_dn}", "bind_password": "${bind_pw}",\
-      "chase_referrals": ${_chase_refs}, "base_ou": "${base_dn}",\
-      "group_dns": ${group_dns}, "use_ssl": ${_use_ssl}, "port": ${port},\
-      "scope": "${scope}", "id_attr": "${id_attr}",\
-      "account_pattern": "${account_pattern}"}
-      | - LDAPARGS
-  }
-  elsif $group_pattern != undef {
-    $_kwargs = @("LDAPARGS"/L)
-      {"host": "${host}", "use_tls": ${_use_tls},\
-      "bind_dn": "${bind_dn}", "bind_password": "${bind_pw}",\
-      "chase_referrals": ${_chase_refs}, "base_ou": "${base_dn}",\
-      "group_dns": ${group_dns}, "use_ssl": ${_use_ssl}, "port": ${port},\
-      "scope": "${scope}", "id_attr": "${id_attr}",\
-      "group_pattern": "${group_pattern}"}
-      | - LDAPARGS
-  }
-  else {
-    $_kwargs = @("LDAPARGS"/L)
-      {"host": "${host}", "use_tls": ${_use_tls},\
-      "bind_dn": "${bind_dn}", "bind_password": "${bind_pw}",\
-      "chase_referrals": ${_chase_refs}, "base_ou": "${base_dn}",\
-      "group_dns": ${group_dns}, "use_ssl": ${_use_ssl}, "port": ${port},\
-      "scope": "${scope}", "id_attr": "${id_attr}"}
-      | - LDAPARGS
-  }
+
+  $_kwargs = to_json($backend_kwargs_raw)
 
   # config
   ini_setting { 'auth_backend':


### PR DESCRIPTION
This allows a CA-Cert to be used for the LDAP connection. 

Additionally, I replaced the big `if` and `ifelese` block with a simple alternative that uses stdlib `to_json` to generate a clean json from a hash. This saves the various condition and the templates behind it. 

This was tested with Puppet 7, stdlib 6.6.0 and Hiera as a source.  